### PR TITLE
reading list: add knicks brunson ipad article

### DIFF
--- a/public/reader/reading-list.json
+++ b/public/reader/reading-list.json
@@ -519,6 +519,14 @@
       "createdAt": "2026-04-08T12:00:00.003Z",
       "metadata": {},
       "read": false
+    },
+    {
+      "id": "1779580800001",
+      "url": "https://www.nytimes.com/athletic/7248400/2026/05/03/knicks-jalen-brunson-uses-ipad-during-games/",
+      "title": "Jalen Brunson Uses iPad During Games",
+      "createdAt": "2026-05-24T12:00:00.001Z",
+      "metadata": {},
+      "read": false
     }
   ]
 }


### PR DESCRIPTION
Adds the Athletic article on Jalen Brunson's in-game iPad use to the antilibrary reading list.