### PR TITLE
add Aleksa Gordic vLLM and Transformer posts to antilibrary

### DIFF
--- a/public/reader/reading-list.json
+++ b/public/reader/reading-list.json
@@ -527,6 +527,22 @@
       "createdAt": "2026-05-24T12:00:00.001Z",
       "metadata": {},
       "read": false
+    },
+    {
+      "id": "1779753600001",
+      "url": "https://www.aleksagordic.com/blog/vllm",
+      "title": "Inside vLLM: Anatomy of a High-Throughput LLM Inference System",
+      "createdAt": "2026-05-26T12:00:00.001Z",
+      "metadata": {},
+      "read": false
+    },
+    {
+      "id": "1779753600002",
+      "url": "https://www.aleksagordic.com/blog/transformer",
+      "title": "The Transformer",
+      "createdAt": "2026-05-26T12:00:00.002Z",
+      "metadata": {},
+      "read": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds two new entries to `public/reader/reading-list.json` under the Antilibrary tab: Aleksa Gordic's vLLM and Transformer blog posts.

## Test plan
- [ ] Verify entries appear in the Antilibrary tab on the reader page