### PR TITLE
add After Automation and Benedict Evans presentations to antilibrary

### DIFF
--- a/public/reader/reading-list.json
+++ b/public/reader/reading-list.json
@@ -543,6 +543,22 @@
       "createdAt": "2026-05-26T12:00:00.002Z",
       "metadata": {},
       "read": false
+    },
+    {
+      "id": "1780012800001",
+      "url": "https://every.to/p/after-automation",
+      "title": "After Automation",
+      "createdAt": "2026-05-27T12:00:00.001Z",
+      "metadata": {},
+      "read": false
+    },
+    {
+      "id": "1780012800002",
+      "url": "https://www.ben-evans.com/presentations",
+      "title": "Presentations — Benedict Evans",
+      "createdAt": "2026-05-27T12:00:00.002Z",
+      "metadata": {},
+      "read": false
     }
   ]
 }


### PR DESCRIPTION
Adds two new links to the antilibrary reading list:
- [After Automation](https://every.to/p/after-automation) (Every)
- [Presentations — Benedict Evans](https://www.ben-evans.com/presentations)