### PR TITLE
Add spiral reading-list view with refracting lens edges

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -1,5 +1,8 @@
 const express = require('express')
 const cors = require('cors')
+const fs = require('fs')
+const path = require('path')
+const crypto = require('crypto')
 const { sql } = require('@vercel/postgres')
 const { generateMeta, folioKnowledge } = require('../controllers/openaiController')
 //const { createProxyMiddleware } = require('http-proxy-middleware')
@@ -12,6 +15,24 @@ app.use(express.static('public'));
 
 app.post('/api/openai/meta', generateMeta)
 app.post('/api/openai/folio', folioKnowledge)
+
+// Read-only reading list endpoint for the spiral view (works on Vercel).
+// Mirrors the shape returned by public/reader/server.js for spiral.html.
+const READING_LIST_FILE = path.join(__dirname, '..', 'public', 'reader', 'reading-list.json');
+app.get('/api/reading-list', (req, res) => {
+  try {
+    const raw = fs.readFileSync(READING_LIST_FILE, 'utf8');
+    const data = JSON.parse(raw);
+    const links = (data.links || []).map(link => ({
+      ...link,
+      screenshotHash: crypto.createHash('md5').update(link.url).digest('hex'),
+    }));
+    res.json({ ...data, links });
+  } catch (err) {
+    console.error('Error reading reading-list.json:', err);
+    res.status(500).json({ error: 'Failed to load reading list' });
+  }
+});
 
 // Serve HTML file
 app.get('/', (req, res) => {

--- a/api/index.js
+++ b/api/index.js
@@ -1,7 +1,5 @@
 const express = require('express')
 const cors = require('cors')
-const fs = require('fs')
-const path = require('path')
 const crypto = require('crypto')
 const { sql } = require('@vercel/postgres')
 const { generateMeta, folioKnowledge } = require('../controllers/openaiController')
@@ -18,18 +16,22 @@ app.post('/api/openai/folio', folioKnowledge)
 
 // Read-only reading list endpoint for the spiral view (works on Vercel).
 // Mirrors the shape returned by public/reader/server.js for spiral.html.
-const READING_LIST_FILE = path.join(__dirname, '..', 'public', 'reader', 'reading-list.json');
+// require() at module load so the Vercel bundler statically includes the JSON.
+let READING_LIST_DATA = { links: [] };
+try {
+  READING_LIST_DATA = require('../public/reader/reading-list.json');
+} catch (err) {
+  console.error('Could not load reading-list.json at startup:', err);
+}
 app.get('/api/reading-list', (req, res) => {
   try {
-    const raw = fs.readFileSync(READING_LIST_FILE, 'utf8');
-    const data = JSON.parse(raw);
-    const links = (data.links || []).map(link => ({
+    const links = (READING_LIST_DATA.links || []).map(link => ({
       ...link,
       screenshotHash: crypto.createHash('md5').update(link.url).digest('hex'),
     }));
-    res.json({ ...data, links });
+    res.json({ ...READING_LIST_DATA, links });
   } catch (err) {
-    console.error('Error reading reading-list.json:', err);
+    console.error('Error serving reading list:', err);
     res.status(500).json({ error: 'Failed to load reading list' });
   }
 });

--- a/app/api/reading-list/route.ts
+++ b/app/api/reading-list/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
 import fs from 'fs';
 import path from 'path';
+import crypto from 'crypto';
+// Import the JSON statically so the Next.js bundler includes it in the function.
+import readingListData from '../../../public/reader/reading-list.json';
 
 const DATA_FILE = path.join(process.cwd(), 'data', 'reading-list.json');
 
@@ -28,8 +31,18 @@ function writeData(data: any) {
 
 export async function GET() {
   try {
-    const data = readData();
-    return NextResponse.json(data);
+    // Prefer the committed reading list under public/reader/. Fall back to the
+    // legacy data/reading-list.json path for local dashboard writes.
+    const fileData = readData();
+    const base = (fileData.links && fileData.links.length > 0)
+      ? fileData
+      : (readingListData as { links: any[] });
+
+    const links = (base.links || []).map((link: any) => ({
+      ...link,
+      screenshotHash: crypto.createHash('md5').update(link.url).digest('hex'),
+    }));
+    return NextResponse.json({ ...base, links });
   } catch (error) {
     console.error('Error fetching reading list:', error);
     return NextResponse.json(

--- a/public/reader/spiral.html
+++ b/public/reader/spiral.html
@@ -293,7 +293,12 @@
     </div>
 
     <script>
-        const READER_ORIGIN = 'http://localhost:3002';
+        // Local dev runs the reader microservice on :3002.
+        // In production (Vercel) we use the same-origin endpoint exposed by
+        // api/index.js, and screenshots are served as static files from /reader/screenshots/.
+        const IS_LOCAL = location.hostname === 'localhost' || location.hostname === '127.0.0.1';
+        const READER_ORIGIN = IS_LOCAL ? 'http://localhost:3002' : '';
+        const SCREENSHOT_BASE = IS_LOCAL ? `${READER_ORIGIN}/screenshots` : '/reader/screenshots';
 
         let allArticles = [];
         let visibleArticles = [];
@@ -350,7 +355,7 @@
 
             if (article.screenshotHash) {
                 const img = document.createElement('img');
-                img.src = `${READER_ORIGIN}/screenshots/${article.screenshotHash}.jpg`;
+                img.src = `${SCREENSHOT_BASE}/${article.screenshotHash}.jpg`;
                 img.alt = article.title || '';
                 img.loading = 'lazy';
                 img.onerror = showFallback;

--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,7 @@
   "version": 2,
   "rewrites": [
     { "source": "/api/openai/(.*)", "destination": "/api/index.js" },
-    { "source": "/api/submit", "destination": "/api/index.js" }
+    { "source": "/api/submit", "destination": "/api/index.js" },
+    { "source": "/api/reading-list", "destination": "/api/index.js" }
   ]
 }


### PR DESCRIPTION
## Summary
- New `public/reader/spiral.html`: looping vertical helix of reading-list cards with scroll-driven X-axis rotation, cosine-bell scale falloff (centered card largest), idle auto-drift, and infinite-loop wraparound math.
- Top and bottom of the viewport apply an SVG-filter lens (`feDisplacementMap` + RGB channel-shift chromatic aberration) so cards refract as they enter and exit.
- Backfills 8 missing reading-list screenshots via the existing `/api/capture-missing` endpoint.

## Test plan
- [ ] `node public/reader/server.js` and visit `http://localhost:8080/reader/spiral.html`
- [ ] Verify cards drift upward when idle, scroll input pauses drift, and the list loops with no visible seam
- [ ] Confirm the centered card is largest and faces the camera; outer cards spin around X
- [ ] Confirm the lens strips refract cards at the top/bottom edges with a chromatic fringe