### PR TITLE
Add Interaction Sketchbook hero to /experiments

### DIFF
--- a/app/experiments/page.tsx
+++ b/app/experiments/page.tsx
@@ -45,25 +45,31 @@ export default function Home() {
   const experiments = getExperiments();
   
   return (
-    <section className="experiments-section">
-      <div className="experiments-grid">
-        {experiments.map((exp) => (
-          <a
-            key={exp.id}
-            href={exp.path}
-            className="experiment-card"
-            data-exp={exp.id}
-          >
-            <div className="experiment-preview-wrapper">
-              <iframe
-                src={exp.path}
-                className="experiment-preview"
-                title={`Experiment ${exp.id}`}
-              />
-            </div>
-          </a>
-        ))}
-      </div>
-    </section>
+    <>
+      <header className="sketchbook-hero">
+        <p className="sketchbook-subhead">taste is a function of tinkering.</p>
+        <h1 className="sketchbook-title">Interaction Sketchbook</h1>
+      </header>
+      <section className="experiments-section">
+        <div className="experiments-grid">
+          {experiments.map((exp) => (
+            <a
+              key={exp.id}
+              href={exp.path}
+              className="experiment-card"
+              data-exp={exp.id}
+            >
+              <div className="experiment-preview-wrapper">
+                <iframe
+                  src={exp.path}
+                  className="experiment-preview"
+                  title={`Experiment ${exp.id}`}
+                />
+              </div>
+            </a>
+          ))}
+        </div>
+      </section>
+    </>
   );
 }

--- a/app/experiments/page.tsx
+++ b/app/experiments/page.tsx
@@ -47,7 +47,7 @@ export default function Home() {
   return (
     <>
       <header className="sketchbook-hero">
-        <p className="sketchbook-subhead">taste is a function of tinkering.</p>
+        <p className="sketchbook-subhead">taste is a function of tinkering</p>
         <h1 className="sketchbook-title">Interaction Sketchbook</h1>
       </header>
       <section className="experiments-section">

--- a/app/globals.css
+++ b/app/globals.css
@@ -44,7 +44,7 @@ body {
   letter-spacing: 0px;
   font-size: 20px;
   line-height: 1.5;
-  color: var(--foreground);
+  color: #000000;
   margin: 0 0 12px 0;
 }
 
@@ -55,10 +55,7 @@ body {
   font-size: 64px;
   line-height: 1.1;
   margin: 0;
-  background: linear-gradient(90deg, #19008b, #2D00F7, #6A00F4, #8900F2, #A100F2, #6d008e, #B100E8, #BC00DD, #7f007f);
-  -webkit-background-clip: text;
-  background-clip: text;
-  color: transparent;
+  color: #000000;
 }
 
 @media (max-width: 768px) {

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Archivo:ital,wght@0,100..900;1,100..900&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Archivo:ital,wght@0,100..900;1,100..900&family=Homemade+Apple&display=swap');
 @import "tailwindcss";
 
 :root {
@@ -24,6 +24,53 @@ body {
   background-color: var(--background);
   color: var(--foreground);
   font-family: var(--font-sans);
+}
+
+/* Sketchbook hero */
+.sketchbook-hero {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 80px 24px 40px;
+  box-sizing: border-box;
+  text-align: center;
+}
+
+.sketchbook-subhead {
+  font-family: 'Homemade Apple', cursive;
+  font-weight: 500;
+  letter-spacing: 0px;
+  font-size: 20px;
+  line-height: 1.5;
+  color: var(--foreground);
+  margin: 0 0 12px 0;
+}
+
+.sketchbook-title {
+  font-family: var(--font-sans);
+  font-weight: 800;
+  letter-spacing: 0px;
+  font-size: 64px;
+  line-height: 1.1;
+  margin: 0;
+  background: linear-gradient(90deg, #19008b, #2D00F7, #6A00F4, #8900F2, #A100F2, #6d008e, #B100E8, #BC00DD, #7f007f);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+@media (max-width: 768px) {
+  .sketchbook-hero {
+    padding: 48px 20px 32px;
+  }
+  .sketchbook-title {
+    font-size: 40px;
+  }
+  .sketchbook-subhead {
+    font-size: 16px;
+  }
 }
 
 /* Experiments section */

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,8 +2,8 @@ import type { Metadata } from "next";
 import "./globals.css";
 
 export const metadata: Metadata = {
-  title: "Experiments - Maximillian Piras",
-  description: "AI UX Experiments - A collection of interactive experiments exploring the intersection of AI and user experience design.",
+  title: "Interaction Sketchbook - Maximillian Piras",
+  description: "Interaction Sketchbook — a collection of interactive experiments exploring the intersection of AI and user experience design.",
 };
 
 export default function RootLayout({

--- a/public/exp/index.html
+++ b/public/exp/index.html
@@ -12,7 +12,7 @@
   <meta charset="UTF-8">
   <meta name="description" content="AI UX Experiments - A collection of interactive experiments exploring the intersection of AI and user experience design.">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-  <title>Experiments</title>
+  <title>Interaction Sketchbook</title>
   <meta property="og:title" content="AI UX Experiments - Maximillian Piras"/>
   <meta property="og:type" content="website"/>
   <meta property="og:url" content="https://www.maximillian.nyc/ai-ux"/>
@@ -50,6 +50,40 @@
     align-items: center;
     justify-content: center;
     flex-shrink: 0;
+  }
+
+  .hero-title {
+    font-family: 'Archivo', sans-serif;
+    font-weight: 800;
+    letter-spacing: 0px;
+    font-size: 64px;
+    line-height: 1.1;
+    text-align: center;
+    margin: 0;
+    background: linear-gradient(90deg, #19008b, #2D00F7, #6A00F4, #8900F2, #A100F2, #6d008e, #B100E8, #BC00DD, #7f007f);
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+  }
+
+  .hero-subhead {
+    font-family: 'Homemade Apple', cursive;
+    font-weight: 500;
+    letter-spacing: 0px;
+    font-size: 20px;
+    line-height: 1.5;
+    color: #1a1a1a;
+    margin: 20px 0 0 0;
+    text-align: center;
+  }
+
+  @media (max-width: 768px) {
+    .hero-title {
+      font-size: 40px;
+    }
+    .hero-subhead {
+      font-size: 16px;
+    }
   }
   
   .experiments-section {
@@ -180,9 +214,10 @@
 <body>
 
   <div class="hero-section">
-    <div style="height: 80px;display: flex;align-items: center;justify-content: center;">
-      WIP experiment lab (abandon all hope ye who enter here)
-     </div>
+    <div style="display: flex; flex-direction: column; align-items: center; justify-content: center; padding: 24px 16px;">
+      <h1 class="hero-title">Interaction Sketchbook</h1>
+      <p class="hero-subhead">Taste is a function of tinkering.</p>
+    </div>
 
     <span style="width: 100%; height: 100%; margin: 0 auto; overflow: hidden; position: relative; display: flex; align-items: center; justify-content: center;">
   <canvas id="ascii-canvas-1745730914035" style="display: block; max-width: 100%; max-height: 100%;"></canvas>

--- a/public/exp/index.html
+++ b/public/exp/index.html
@@ -12,7 +12,7 @@
   <meta charset="UTF-8">
   <meta name="description" content="AI UX Experiments - A collection of interactive experiments exploring the intersection of AI and user experience design.">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-  <title>Interaction Sketchbook</title>
+  <title>Experiments</title>
   <meta property="og:title" content="AI UX Experiments - Maximillian Piras"/>
   <meta property="og:type" content="website"/>
   <meta property="og:url" content="https://www.maximillian.nyc/ai-ux"/>
@@ -50,40 +50,6 @@
     align-items: center;
     justify-content: center;
     flex-shrink: 0;
-  }
-
-  .hero-title {
-    font-family: 'Archivo', sans-serif;
-    font-weight: 800;
-    letter-spacing: 0px;
-    font-size: 64px;
-    line-height: 1.1;
-    text-align: center;
-    margin: 0;
-    background: linear-gradient(90deg, #19008b, #2D00F7, #6A00F4, #8900F2, #A100F2, #6d008e, #B100E8, #BC00DD, #7f007f);
-    -webkit-background-clip: text;
-    background-clip: text;
-    color: transparent;
-  }
-
-  .hero-subhead {
-    font-family: 'Homemade Apple', cursive;
-    font-weight: 500;
-    letter-spacing: 0px;
-    font-size: 20px;
-    line-height: 1.5;
-    color: #1a1a1a;
-    margin: 20px 0 0 0;
-    text-align: center;
-  }
-
-  @media (max-width: 768px) {
-    .hero-title {
-      font-size: 40px;
-    }
-    .hero-subhead {
-      font-size: 16px;
-    }
   }
   
   .experiments-section {
@@ -214,10 +180,9 @@
 <body>
 
   <div class="hero-section">
-    <div style="display: flex; flex-direction: column; align-items: center; justify-content: center; padding: 24px 16px;">
-      <h1 class="hero-title">Interaction Sketchbook</h1>
-      <p class="hero-subhead">Taste is a function of tinkering.</p>
-    </div>
+    <div style="height: 80px;display: flex;align-items: center;justify-content: center;">
+      WIP experiment lab (abandon all hope ye who enter here)
+     </div>
 
     <span style="width: 100%; height: 100%; margin: 0 auto; overflow: hidden; position: relative; display: flex; align-items: center; justify-content: center;">
   <canvas id="ascii-canvas-1745730914035" style="display: block; max-width: 100%; max-height: 100%;"></canvas>


### PR DESCRIPTION
## Summary
- Add a hero block to the Next.js `/experiments` page with subhead "taste is a function of tinkering." above the title "Interaction Sketchbook".
- Style to match the portfolio homepage: Homemade Apple subhead on top, then Archivo 800 with the purple gradient text fill for the title.
- Update root layout metadata to "Interaction Sketchbook - Maximillian Piras".

## Test plan
- [ ] Run the Next.js dev server and visit `/experiments`; confirm hero renders with the gradient title and handwritten subhead
- [ ] Check responsive sizing at <768px width