### PR TITLE
Interaction Sketchbook alternate layout exploration

### DIFF
--- a/app/experiments/folio/FolioGallery.tsx
+++ b/app/experiments/folio/FolioGallery.tsx
@@ -1,0 +1,147 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+interface Experiment {
+  id: string;
+  path: string;
+}
+
+const CARD_MARGIN = 16;
+
+export default function FolioGallery({ experiments }: { experiments: Experiment[] }) {
+  const [activeIndex, setActiveIndex] = useState(0);
+  const cardRefs = useRef<(HTMLAnchorElement | null)[]>([]);
+  const sidebarItemRefs = useRef<(HTMLAnchorElement | null)[]>([]);
+
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const snapTimerRef = useRef<number | null>(null);
+  const isProgrammaticScroll = useRef(false);
+
+  useEffect(() => {
+    const root = rootRef.current;
+    if (!root) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            const idx = Number((entry.target as HTMLElement).dataset.index);
+            setActiveIndex(idx);
+          }
+        });
+      },
+      { root, rootMargin: '-40% 0px -40% 0px', threshold: 0 }
+    );
+
+    cardRefs.current.forEach((el) => el && observer.observe(el));
+
+    const snapToNearest = () => {
+      const scrollTop = root.scrollTop;
+      let nearestIdx = 0;
+      let nearestDist = Infinity;
+      cardRefs.current.forEach((card, i) => {
+        if (!card) return;
+        const targetTop = card.offsetTop - CARD_MARGIN;
+        const dist = Math.abs(targetTop - scrollTop);
+        if (dist < nearestDist) {
+          nearestDist = dist;
+          nearestIdx = i;
+        }
+      });
+      const target = cardRefs.current[nearestIdx];
+      if (!target) return;
+      const targetTop = target.offsetTop - CARD_MARGIN;
+      if (Math.abs(targetTop - scrollTop) < 2) return;
+      isProgrammaticScroll.current = true;
+      root.scrollTo({ top: targetTop, behavior: 'smooth' });
+    };
+
+    const supportsScrollEnd = 'onscrollend' in window;
+
+    const onScrollEnd = () => {
+      if (isProgrammaticScroll.current) {
+        isProgrammaticScroll.current = false;
+        return;
+      }
+      snapToNearest();
+    };
+
+    const onScrollFallback = () => {
+      if (snapTimerRef.current) window.clearTimeout(snapTimerRef.current);
+      snapTimerRef.current = window.setTimeout(() => {
+        if (isProgrammaticScroll.current) {
+          isProgrammaticScroll.current = false;
+          return;
+        }
+        snapToNearest();
+      }, 10);
+    };
+
+    if (supportsScrollEnd) {
+      root.addEventListener('scrollend', onScrollEnd, { passive: true });
+    } else {
+      root.addEventListener('scroll', onScrollFallback, { passive: true });
+    }
+
+    return () => {
+      observer.disconnect();
+      if (supportsScrollEnd) root.removeEventListener('scrollend', onScrollEnd);
+      else root.removeEventListener('scroll', onScrollFallback);
+      if (snapTimerRef.current) window.clearTimeout(snapTimerRef.current);
+    };
+  }, [experiments.length]);
+
+  const scrollToCard = (idx: number) => {
+    const root = rootRef.current;
+    const target = cardRefs.current[idx];
+    if (!root || !target) return;
+    isProgrammaticScroll.current = true;
+    root.scrollTo({ top: target.offsetTop - CARD_MARGIN, behavior: 'smooth' });
+  };
+
+  return (
+    <div className="folio-root" ref={rootRef}>
+      <div className="folio-layout">
+        <aside className="folio-sidebar">
+          <div className="folio-eyebrow">Interaction Sketchbook</div>
+          {experiments.map((exp, i) => (
+            <a
+              key={exp.id}
+              ref={(el) => { sidebarItemRefs.current[i] = el; }}
+              href={`#exp-${exp.id}`}
+              className={`folio-sidebar-item ${i === activeIndex ? 'active' : ''}`}
+              onClick={(e) => {
+                e.preventDefault();
+                scrollToCard(i);
+              }}
+            >
+              <span className="title">{exp.id}</span>
+            </a>
+          ))}
+        </aside>
+
+        <main className="folio-cards">
+          {experiments.map((exp, i) => (
+            <a
+              key={exp.id}
+              id={`exp-${exp.id}`}
+              ref={(el) => { cardRefs.current[i] = el; }}
+              data-index={i}
+              href={exp.path}
+              className="folio-card"
+              data-exp={exp.id}
+            >
+              <iframe
+                src={exp.path}
+                className="folio-card-frame"
+                title={`Experiment ${exp.id}`}
+                loading="lazy"
+              />
+            </a>
+          ))}
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/app/experiments/folio/page.tsx
+++ b/app/experiments/folio/page.tsx
@@ -1,0 +1,48 @@
+import { readdirSync, statSync, existsSync } from 'fs';
+import { join } from 'path';
+import FolioGallery from './FolioGallery';
+
+interface Experiment {
+  id: string;
+  path: string;
+}
+
+const NEXTJS_EXPERIMENTS = ['006', '012', '013', '026', '027', '028'];
+
+function getExperiments(): Experiment[] {
+  const staticDir = join(process.cwd(), 'public', 'static');
+
+  try {
+    const entries = readdirSync(staticDir);
+
+    const staticExperiments = entries
+      .filter((entry) => {
+        if (!/^\d{3}$/.test(entry)) return false;
+        const fullPath = join(staticDir, entry);
+        if (!statSync(fullPath).isDirectory()) return false;
+        return existsSync(join(fullPath, 'index.html'));
+      })
+      .map((dir) => ({
+        id: dir,
+        path: NEXTJS_EXPERIMENTS.includes(dir)
+          ? `/experiments/${dir}`
+          : `/static/${dir}/index.html`,
+      }));
+
+    const appDir = join(process.cwd(), 'app', 'experiments');
+    const nextjsOnly = NEXTJS_EXPERIMENTS
+      .filter(id => !staticExperiments.find(e => e.id === id))
+      .filter(id => existsSync(join(appDir, id, 'page.tsx')))
+      .map(id => ({ id, path: `/experiments/${id}` }));
+
+    return [...staticExperiments, ...nextjsOnly].sort((a, b) => a.id.localeCompare(b.id));
+  } catch (error) {
+    console.error('Error reading experiments directory:', error);
+    return [];
+  }
+}
+
+export default function FolioPage() {
+  const experiments = getExperiments();
+  return <FolioGallery experiments={experiments} />;
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -197,3 +197,200 @@ body {
     text-wrap: balance;
   }
 }
+
+/* ─── Folio variant gallery (scoped) ───────────────────────────── */
+.folio-root {
+  --folio-bg: #ffffff;
+  --folio-fg: #1a1a1a;
+  --folio-muted: #8a8a8a;
+  --folio-muted-2: #c4c4c4;
+  --folio-card-bg: #f5f5f5;
+  --folio-radius: 36px;
+
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  margin: 0;
+  padding: 0;
+  background: var(--folio-bg);
+  color: var(--folio-fg);
+  font-family: var(--font-sans);
+  overflow-y: auto;
+  overflow-x: hidden;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  z-index: 1;
+}
+
+.folio-layout {
+  display: grid;
+  grid-template-columns: 1fr 2fr;
+  gap: 16px;
+  width: 100%;
+  margin: 0;
+  padding: 0 16px;
+  box-sizing: border-box;
+}
+
+.folio-sidebar {
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 14px;
+  overflow-y: auto;
+  scrollbar-width: none;
+}
+.folio-sidebar::-webkit-scrollbar { display: none; }
+
+.folio-eyebrow {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--folio-muted-2);
+  margin-bottom: 24px;
+  font-weight: 500;
+  text-align: center;
+}
+
+.folio-sidebar-item {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  font-size: 15px;
+  font-weight: 500;
+  color: var(--folio-muted-2);
+  letter-spacing: -0.01em;
+  cursor: pointer;
+  text-decoration: none;
+  transition: color 0.35s ease, font-size 0.35s ease, font-weight 0.35s ease;
+  line-height: 1.3;
+  text-align: center;
+}
+.folio-sidebar-item:hover { color: var(--folio-muted); }
+.folio-sidebar-item.active {
+  color: var(--folio-fg);
+  font-size: 22px;
+  font-weight: 700;
+}
+
+.folio-sidebar-item .num {
+  font-size: 10px;
+  color: var(--folio-muted-2);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.05em;
+  flex-shrink: 0;
+  transition: color 0.35s ease;
+}
+.folio-sidebar-item.active .num { color: var(--folio-muted); }
+
+.folio-sidebar-item .tag {
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--folio-muted);
+  opacity: 0;
+  transform: translateX(-4px);
+  transition: opacity 0.35s ease, transform 0.35s ease;
+  align-self: center;
+}
+.folio-sidebar-item.active .tag {
+  opacity: 1;
+  transform: translateX(0);
+}
+
+.folio-cards {
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  align-items: stretch;
+}
+.folio-card {
+  position: relative;
+  width: 100%;
+  height: calc(100vh - 32px);
+  margin: 16px 0;
+  border-radius: var(--folio-radius);
+  overflow: hidden;
+  background: var(--folio-card-bg);
+  box-shadow:
+    0 20px 40px rgba(0, 0, 0, 0.08),
+    inset 0 0 0 1px rgba(0, 0, 0, 0.04);
+  scroll-margin-top: 80px;
+  text-decoration: none;
+  color: inherit;
+  transition: transform 0.5s ease, box-shadow 0.5s ease;
+}
+.folio-card:hover {
+  transform: translateY(-4px);
+  box-shadow:
+    0 30px 60px rgba(0, 0, 0, 0.12),
+    inset 0 0 0 1px rgba(0, 0, 0, 0.06);
+}
+
+.folio-card-frame {
+  width: 100%;
+  height: 100%;
+  border: none;
+  display: block;
+  background: var(--folio-card-bg);
+  pointer-events: none;
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+
+.folio-card-meta {
+  position: absolute;
+  left: 28px;
+  bottom: 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  z-index: 2;
+  mix-blend-mode: difference;
+  color: #fff;
+}
+.folio-card-meta .title {
+  font-size: 18px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+.folio-card-meta .subtitle {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  opacity: 0.7;
+}
+
+.folio-card-number {
+  position: absolute;
+  top: 24px;
+  right: 28px;
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.1em;
+  color: #fff;
+  mix-blend-mode: difference;
+  font-variant-numeric: tabular-nums;
+  z-index: 2;
+}
+
+@media (max-width: 900px) {
+  .folio-layout { grid-template-columns: 1fr; }
+  .folio-sidebar {
+    position: relative;
+    height: auto;
+    padding: 40px 32px 0;
+    justify-content: flex-start;
+  }
+  .folio-cards { padding: 60px 24px; gap: 80px; }
+  .folio-sidebar-item.active { font-size: 18px; }
+}


### PR DESCRIPTION
## Summary
- New route at `/experiments/folio`: a second take on the experiments page modeled after [motionin.design/gallery/folio](https://www.motionin.design/gallery/folio) — two-column layout with a centered numeric sidebar (active item bolds/scales) and a 2/3-width right column of large, viewport-filling cards.
- Cards snap into place on scroll using JS (`scrollend` with a debounced fallback) for symmetric up/down behavior; sidebar clicks scroll-to-card via the same path. Iframes render at natural 1:1 inside the larger cards.
- All styles scoped under `.folio-root` in `app/globals.css`; the existing `/experiments` grid is unchanged.

## Test plan
- [ ] Visit `/experiments/folio` and scroll: each card should snap fully into the viewport with 16px margins above/below
- [ ] Scrolling up should snap as cleanly as scrolling down
- [ ] Clicking a number in the sidebar scrolls to the corresponding card and updates the active state
- [ ] Existing `/experiments` page renders unchanged