### PR TITLE
Make Interaction Sketchbook index interactive

### DIFF
--- a/app/experiments/folio/FolioGallery.tsx
+++ b/app/experiments/folio/FolioGallery.tsx
@@ -11,7 +11,7 @@ const CARD_MARGIN = 16;
 
 export default function FolioGallery({ experiments }: { experiments: Experiment[] }) {
   const [activeIndex, setActiveIndex] = useState(0);
-  const cardRefs = useRef<(HTMLAnchorElement | null)[]>([]);
+  const cardRefs = useRef<(HTMLElement | null)[]>([]);
   const sidebarItemRefs = useRef<(HTMLAnchorElement | null)[]>([]);
 
   const rootRef = useRef<HTMLDivElement | null>(null);
@@ -123,13 +123,12 @@ export default function FolioGallery({ experiments }: { experiments: Experiment[
 
         <main className="folio-cards">
           {experiments.map((exp, i) => (
-            <a
+            <article
               key={exp.id}
               id={`exp-${exp.id}`}
               ref={(el) => { cardRefs.current[i] = el; }}
               data-index={i}
-              href={exp.path}
-              className="folio-card"
+              className={`folio-card ${i === activeIndex ? 'is-active' : ''}`}
               data-exp={exp.id}
             >
               <iframe
@@ -138,7 +137,7 @@ export default function FolioGallery({ experiments }: { experiments: Experiment[
                 title={`Experiment ${exp.id}`}
                 loading="lazy"
               />
-            </a>
+            </article>
           ))}
         </main>
       </div>

--- a/app/experiments/folio/FolioGallery.tsx
+++ b/app/experiments/folio/FolioGallery.tsx
@@ -102,13 +102,12 @@ export default function FolioGallery({ experiments }: { experiments: Experiment[
 
   return (
     <div className="folio-root" ref={rootRef}>
-      <header className="sketchbook-hero folio-hero">
-        <p className="sketchbook-subhead">taste is a function of tinkering</p>
-        <h1 className="sketchbook-title">Interaction Sketchbook</h1>
-      </header>
       <div className="folio-layout">
         <aside className="folio-sidebar">
-          <div className="folio-eyebrow">Interaction Sketchbook</div>
+          <header className="sketchbook-hero folio-hero">
+            <p className="sketchbook-subhead">taste is a function of tinkering</p>
+            <h1 className="sketchbook-title">Interaction Sketchbook</h1>
+          </header>
           {experiments.map((exp, i) => (
             <a
               key={exp.id}

--- a/app/experiments/folio/FolioGallery.tsx
+++ b/app/experiments/folio/FolioGallery.tsx
@@ -102,6 +102,10 @@ export default function FolioGallery({ experiments }: { experiments: Experiment[
 
   return (
     <div className="folio-root" ref={rootRef}>
+      <header className="sketchbook-hero folio-hero">
+        <p className="sketchbook-subhead">taste is a function of tinkering</p>
+        <h1 className="sketchbook-title">Interaction Sketchbook</h1>
+      </header>
       <div className="folio-layout">
         <aside className="folio-sidebar">
           <div className="folio-eyebrow">Interaction Sketchbook</div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,10 +1,10 @@
-@import url('https://fonts.googleapis.com/css2?family=Archivo:ital,wght@0,100..900;1,100..900&family=Homemade+Apple&display=swap');
 @import "tailwindcss";
 
 :root {
   --background: #ffffff;
   --foreground: #1a1a1a;
-  --font-sans: 'Archivo', sans-serif;
+  --font-sans: var(--font-archivo), 'Archivo', sans-serif;
+  --font-handwritten: var(--font-homemade-apple), 'Homemade Apple', cursive;
 }
 
 @theme inline {
@@ -39,7 +39,7 @@ body {
 }
 
 .sketchbook-subhead {
-  font-family: 'Homemade Apple', cursive;
+  font-family: var(--font-handwritten);
   font-weight: 500;
   letter-spacing: 0px;
   font-size: 20px;

--- a/app/globals.css
+++ b/app/globals.css
@@ -324,12 +324,10 @@ body {
     0 20px 40px rgba(0, 0, 0, 0.08),
     inset 0 0 0 1px rgba(0, 0, 0, 0.04);
   scroll-margin-top: 80px;
-  text-decoration: none;
   color: inherit;
-  transition: transform 0.5s ease, box-shadow 0.5s ease;
+  transition: box-shadow 0.5s ease;
 }
-.folio-card:hover {
-  transform: translateY(-4px);
+.folio-card.is-active {
   box-shadow:
     0 30px 60px rgba(0, 0, 0, 0.12),
     inset 0 0 0 1px rgba(0, 0, 0, 0.06);
@@ -345,6 +343,10 @@ body {
   position: absolute;
   top: 0;
   left: 0;
+  transition: opacity 0.3s ease;
+}
+.folio-card.is-active .folio-card-frame {
+  pointer-events: auto;
 }
 
 .folio-card-meta {

--- a/app/globals.css
+++ b/app/globals.css
@@ -258,6 +258,27 @@ body {
   text-align: center;
 }
 
+/* Sketchbook hero scoped to the folio sidebar: same fonts, sidebar-fit sizing */
+.folio-hero {
+  padding: 0;
+  margin-bottom: 32px;
+}
+.folio-hero .sketchbook-subhead {
+  font-size: 16px;
+  margin-bottom: 8px;
+  color: var(--folio-fg);
+}
+.folio-hero .sketchbook-title {
+  font-size: 40px;
+  line-height: 1.05;
+  color: var(--folio-fg);
+}
+@media (max-width: 900px) {
+  .folio-hero { margin-bottom: 20px; }
+  .folio-hero .sketchbook-title { font-size: 32px; }
+  .folio-hero .sketchbook-subhead { font-size: 14px; }
+}
+
 .folio-sidebar-item {
   display: flex;
   align-items: center;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,20 @@
 import type { Metadata } from "next";
+import { Archivo, Homemade_Apple } from "next/font/google";
 import "./globals.css";
+
+const archivo = Archivo({
+  subsets: ["latin"],
+  weight: ["100", "200", "300", "400", "500", "600", "700", "800", "900"],
+  variable: "--font-archivo",
+  display: "swap",
+});
+
+const homemadeApple = Homemade_Apple({
+  subsets: ["latin"],
+  weight: "400",
+  variable: "--font-homemade-apple",
+  display: "swap",
+});
 
 export const metadata: Metadata = {
   title: "Interaction Sketchbook - Maximillian Piras",
@@ -12,7 +27,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" className={`${archivo.variable} ${homemadeApple.variable}`}>
       <body>{children}</body>
     </html>
   );


### PR DESCRIPTION
## Summary
- Drops the card-level link wrapper on `/experiments/folio` so each tile is the live experiment itself. Pointer events are enabled only on the centered (active) card, so scrolling past inactive tiles isn't trapped.
- Removes the hover-lift on cards (no longer link-like) — the active card now signals itself with a deeper shadow.
- Adds the `.sketchbook-hero` header from `/experiments` to the top of the folio variant so it leads with the same on-brand framing.

## Test plan
- [ ] Visit `/experiments/folio` — hero renders at the top with "Interaction Sketchbook" + subhead.
- [ ] Scroll past the hero — sidebar pins, first card becomes active with deeper shadow.
- [ ] Click into the centered tile — interactions land on the experiment (drag, click, type).
- [ ] Hover an inactive tile — pointer events stay off, scroll keeps moving past it.
- [ ] Snap behavior still works: scroll end snaps to nearest card; sidebar item click scrolls to its card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)