### PR TITLE
Add design-system reference at unlisted /system route

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-> **Design system:** Before designing or generating any new UI, read `content/system.mdx` — the single source of truth for tokens, type, components (`registry/`), and patterns. It renders at the unlisted `/system` route (`app/system/`). `app/globals.css` is canonical for token values; keep `content/system.mdx` in sync when they change.
+> **Design system:** Before designing or generating any new UI, read `content/system.mdx` — the reference for color/type/radius/elevation/motion tokens, chrome components (logo, nav, minimap), and the `registry/` primitives. It renders at the unlisted `/system` route (`app/system/`). `app/globals.css` is the canonical source for token values: when the code and the doc disagree, the code wins — update `content/system.mdx` to match.
 
 ## Project Overview
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,8 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+> **Design system:** Before designing or generating any new UI, read `content/system.mdx` — the single source of truth for tokens, type, components (`registry/`), and patterns. It renders at the unlisted `/system` route (`app/system/`). `app/globals.css` is canonical for token values; keep `content/system.mdx` in sync when they change.
+
 ## Project Overview
 
 Personal design portfolio of Maximillian Piras showcasing product design work for tech startups, with specialization in AI-powered interfaces, UX design, and creative technology. The site features interactive card stacks, AI chat integration, and animated UI components.

--- a/LLMs.txt
+++ b/LLMs.txt
@@ -20,6 +20,9 @@ This is the personal portfolio of Maximillian Piras, a product designer speciali
 - `controllers/openaiController.js` - AI chat functionality and API handling
 - `public/components/` - Modular UI components (CardStack, ChatIntelligence, etc.)
 
+## Design System (Reference)
+The canonical reference for visual design — color/type/radius/elevation/motion tokens, reusable components (`registry/`), and recurring patterns — lives in `content/system.mdx` and renders at the unlisted `/system` route. Read it before designing or generating new UI. `app/globals.css` holds the canonical token values.
+
 ## Design Philosophy
 - **Focus**: Amplifying human capabilities with delightful & instinctual technology
 - **Specialties**: AI interface design, animation, branding, illustration

--- a/app/system/components/ChromeDemos.tsx
+++ b/app/system/components/ChromeDemos.tsx
@@ -32,10 +32,20 @@ export function NavDemo() {
   );
 }
 
-const MINIMAP_SECTIONS = ['Color', 'Typography', 'Radius', 'Elevation', 'Motion'];
+// Mix of h2 (level 2) and h3 (level 3) so the demo shows the sub-notch design.
+const MINIMAP_SECTIONS = [
+  { label: 'Color', level: 2 },
+  { label: 'Typography', level: 2 },
+  { label: 'Components', level: 2 },
+  { label: 'Logo', level: 3 },
+  { label: 'Nav bar', level: 3 },
+  { label: 'Minimap', level: 3 },
+];
 
 export function MinimapDemo() {
-  const [active, setActive] = useState(1);
+  // Active is "section in view" — driven by scroll in the real component, so it
+  // doesn't follow the cursor here. Clicking a label jumps to it (sets active).
+  const [active, setActive] = useState(2);
   const [open, setOpen] = useState(false);
   return (
     <div
@@ -46,9 +56,8 @@ export function MinimapDemo() {
       <div className="minimap-notches">
         {MINIMAP_SECTIONS.map((s, i) => (
           <div
-            key={s}
-            className={`minimap-notch ${i === active ? 'minimap-notch--active' : ''}`}
-            onMouseEnter={() => setActive(i)}
+            key={s.label}
+            className={`minimap-notch ${s.level === 3 ? 'minimap-notch--sub' : ''} ${i === active ? 'minimap-notch--active' : ''}`}
           />
         ))}
       </div>
@@ -56,13 +65,15 @@ export function MinimapDemo() {
         <div className="minimap-popover">
           {MINIMAP_SECTIONS.map((s, i) => (
             <a
-              key={s}
+              key={s.label}
               href="#"
-              className={`minimap-link ${i === active ? 'minimap-link--active' : ''}`}
-              onMouseEnter={() => setActive(i)}
-              onClick={(e) => e.preventDefault()}
+              className={`minimap-link ${s.level === 3 ? 'minimap-link--sub' : ''} ${i === active ? 'minimap-link--active' : ''}`}
+              onClick={(e) => {
+                e.preventDefault();
+                setActive(i);
+              }}
             >
-              {s}
+              {s.label}
             </a>
           ))}
         </div>

--- a/app/system/components/ChromeDemos.tsx
+++ b/app/system/components/ChromeDemos.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { useState } from 'react';
+
+/**
+ * Lightly-interactive replicas of the site chrome, for the /system previews.
+ * They convey behavior (hover, active selection, popover) without navigating
+ * away. The real components live in app/blog/ — see each ComponentPreview's
+ * `source`. The live Minimap is also mounted on this page's right rail.
+ */
+
+const NAV_ITEMS = ['Work', 'Words', 'About'];
+
+export function NavDemo() {
+  const [active, setActive] = useState(0);
+  return (
+    <nav className="nav-demo">
+      {NAV_ITEMS.map((label, i) => (
+        <a
+          key={label}
+          href="#"
+          className={i === active ? 'active' : ''}
+          onClick={(e) => {
+            e.preventDefault();
+            setActive(i);
+          }}
+        >
+          {label}
+        </a>
+      ))}
+    </nav>
+  );
+}
+
+const MINIMAP_SECTIONS = ['Color', 'Typography', 'Radius', 'Elevation', 'Motion'];
+
+export function MinimapDemo() {
+  const [active, setActive] = useState(1);
+  const [open, setOpen] = useState(false);
+  return (
+    <div
+      className="minimap-demo-wrap"
+      onMouseEnter={() => setOpen(true)}
+      onMouseLeave={() => setOpen(false)}
+    >
+      <div className="minimap-notches">
+        {MINIMAP_SECTIONS.map((s, i) => (
+          <div
+            key={s}
+            className={`minimap-notch ${i === active ? 'minimap-notch--active' : ''}`}
+            onMouseEnter={() => setActive(i)}
+          />
+        ))}
+      </div>
+      {open && (
+        <div className="minimap-popover">
+          {MINIMAP_SECTIONS.map((s, i) => (
+            <a
+              key={s}
+              href="#"
+              className={`minimap-link ${i === active ? 'minimap-link--active' : ''}`}
+              onMouseEnter={() => setActive(i)}
+              onClick={(e) => e.preventDefault()}
+            >
+              {s}
+            </a>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/system/components/ComponentPreview.tsx
+++ b/app/system/components/ComponentPreview.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+
+/**
+ * Renders a live example (children) inside a framed canvas, with the
+ * corresponding source shown below it. Authored in content/system.mdx as:
+ *
+ *   <ComponentPreview code={`<BlurFade inView>Hello</BlurFade>`}>
+ *     <BlurFade inView>Hello</BlurFade>
+ *   </ComponentPreview>
+ *
+ * The live element and the code string are kept separate on purpose so the
+ * preview always reflects real, runnable code from the registry.
+ */
+export function ComponentPreview({
+  title,
+  source,
+  code,
+  background = 'light',
+  children,
+}: {
+  title?: string;
+  /** Where the component lives in the repo, e.g. registry/ui/blur-fade.tsx */
+  source?: string;
+  /** Source snippet shown beneath the canvas */
+  code: string;
+  background?: 'light' | 'dark' | 'checker';
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="component-preview">
+      {(title || source) && (
+        <div className="component-preview-head">
+          {title ? <span className="component-preview-title">{title}</span> : null}
+          {source ? <code className="component-preview-source">{source}</code> : null}
+        </div>
+      )}
+      <div className={`component-preview-canvas component-preview-canvas--${background}`}>
+        {children}
+      </div>
+      <pre className="component-preview-code">
+        <code>{code}</code>
+      </pre>
+    </div>
+  );
+}

--- a/app/system/components/ComponentPreview.tsx
+++ b/app/system/components/ComponentPreview.tsx
@@ -1,45 +1,60 @@
-import React from 'react';
+'use client';
+
+import { useState } from 'react';
 
 /**
- * Renders a live example (children) inside a framed canvas, with the
- * corresponding source shown below it. Authored in content/system.mdx as:
+ * shadcn-style preview card: a Preview / Code tab toggle over a single panel.
+ * The Preview tab renders the real, interactive component (children); the Code
+ * tab shows the corresponding source. Authored in content/system.mdx as:
  *
- *   <ComponentPreview code={`<BlurFade inView>Hello</BlurFade>`}>
- *     <BlurFade inView>Hello</BlurFade>
+ *   <ComponentPreview source="app/blog/Minimap.tsx" code={`<Minimap />`}>
+ *     <MinimapDemo />
  *   </ComponentPreview>
- *
- * The live element and the code string are kept separate on purpose so the
- * preview always reflects real, runnable code from the registry.
  */
 export function ComponentPreview({
-  title,
   source,
   code,
   background = 'light',
   children,
 }: {
-  title?: string;
-  /** Where the component lives in the repo, e.g. registry/ui/blur-fade.tsx */
+  /** Where the component lives in the repo, e.g. app/blog/Minimap.tsx */
   source?: string;
-  /** Source snippet shown beneath the canvas */
+  /** Source snippet shown in the Code tab */
   code: string;
   background?: 'light' | 'dark' | 'checker';
   children: React.ReactNode;
 }) {
+  const [tab, setTab] = useState<'preview' | 'code'>('preview');
   return (
     <div className="component-preview">
-      {(title || source) && (
-        <div className="component-preview-head">
-          {title ? <span className="component-preview-title">{title}</span> : null}
-          {source ? <code className="component-preview-source">{source}</code> : null}
-        </div>
-      )}
-      <div className={`component-preview-canvas component-preview-canvas--${background}`}>
-        {children}
+      <div className="component-preview-tabs" role="tablist">
+        <button
+          role="tab"
+          aria-selected={tab === 'preview'}
+          className={tab === 'preview' ? 'is-active' : ''}
+          onClick={() => setTab('preview')}
+        >
+          Preview
+        </button>
+        <button
+          role="tab"
+          aria-selected={tab === 'code'}
+          className={tab === 'code' ? 'is-active' : ''}
+          onClick={() => setTab('code')}
+        >
+          Code
+        </button>
+        {source ? <code className="component-preview-source">{source}</code> : null}
       </div>
-      <pre className="component-preview-code">
-        <code>{code}</code>
-      </pre>
+      {tab === 'preview' ? (
+        <div className={`component-preview-canvas component-preview-canvas--${background}`}>
+          {children}
+        </div>
+      ) : (
+        <pre className="component-preview-code">
+          <code>{code}</code>
+        </pre>
+      )}
     </div>
   );
 }

--- a/app/system/components/ComponentPreview.tsx
+++ b/app/system/components/ComponentPreview.tsx
@@ -15,13 +15,16 @@ export function ComponentPreview({
   source,
   code,
   background = 'light',
+  tall = false,
   children,
 }: {
   /** Where the component lives in the repo, e.g. app/blog/Minimap.tsx */
   source?: string;
   /** Source snippet shown in the Code tab */
   code: string;
-  background?: 'light' | 'dark' | 'checker';
+  background?: 'light' | 'dark' | 'checker' | 'glass';
+  /** Taller, top-aligned canvas — for content that needs vertical room (popovers). */
+  tall?: boolean;
   children: React.ReactNode;
 }) {
   const [tab, setTab] = useState<'preview' | 'code'>('preview');
@@ -47,7 +50,9 @@ export function ComponentPreview({
         {source ? <code className="component-preview-source">{source}</code> : null}
       </div>
       {tab === 'preview' ? (
-        <div className={`component-preview-canvas component-preview-canvas--${background}`}>
+        <div
+          className={`component-preview-canvas component-preview-canvas--${background}${tall ? ' component-preview-canvas--tall' : ''}`}
+        >
           {children}
         </div>
       ) : (

--- a/app/system/components/ComponentPreview.tsx
+++ b/app/system/components/ComponentPreview.tsx
@@ -1,65 +1,31 @@
-'use client';
-
-import { useState } from 'react';
+import React from 'react';
 
 /**
- * shadcn-style preview card: a Preview / Code tab toggle over a single panel.
- * The Preview tab renders the real, interactive component (children); the Code
- * tab shows the corresponding source. Authored in content/system.mdx as:
+ * Frames a live, interactive component example in a bordered card.
+ * Authored in content/system.mdx as:
  *
- *   <ComponentPreview source="app/blog/Minimap.tsx" code={`<Minimap />`}>
- *     <MinimapDemo />
- *   </ComponentPreview>
+ *   <ComponentPreview background="glass"><NavDemo /></ComponentPreview>
+ *
+ * The example itself (children) carries any interactivity; this wrapper is
+ * presentational. Where each component lives is noted in the section prose.
  */
 export function ComponentPreview({
-  source,
-  code,
   background = 'light',
   tall = false,
   children,
 }: {
-  /** Where the component lives in the repo, e.g. app/blog/Minimap.tsx */
-  source?: string;
-  /** Source snippet shown in the Code tab */
-  code: string;
   background?: 'light' | 'dark' | 'checker' | 'glass';
   /** Taller, top-aligned canvas — for content that needs vertical room (popovers). */
   tall?: boolean;
   children: React.ReactNode;
 }) {
-  const [tab, setTab] = useState<'preview' | 'code'>('preview');
   return (
     <div className="component-preview">
-      <div className="component-preview-tabs" role="tablist">
-        <button
-          role="tab"
-          aria-selected={tab === 'preview'}
-          className={tab === 'preview' ? 'is-active' : ''}
-          onClick={() => setTab('preview')}
-        >
-          Preview
-        </button>
-        <button
-          role="tab"
-          aria-selected={tab === 'code'}
-          className={tab === 'code' ? 'is-active' : ''}
-          onClick={() => setTab('code')}
-        >
-          Code
-        </button>
-        {source ? <code className="component-preview-source">{source}</code> : null}
+      <div
+        className={`component-preview-canvas component-preview-canvas--${background}${tall ? ' component-preview-canvas--tall' : ''}`}
+      >
+        {children}
       </div>
-      {tab === 'preview' ? (
-        <div
-          className={`component-preview-canvas component-preview-canvas--${background}${tall ? ' component-preview-canvas--tall' : ''}`}
-        >
-          {children}
-        </div>
-      ) : (
-        <pre className="component-preview-code">
-          <code>{code}</code>
-        </pre>
-      )}
     </div>
   );
 }

--- a/app/system/components/TokenSwatch.tsx
+++ b/app/system/components/TokenSwatch.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+
+/**
+ * Doc-only presentational helpers for the design-system page.
+ * These render token values from globals.css / blog.css as visual specimens.
+ * They are passed into MDXRemote so content/system.mdx can use them as tags.
+ * No interactivity -> server components.
+ */
+
+export function Swatches({ children }: { children: React.ReactNode }) {
+  return <div className="token-grid">{children}</div>;
+}
+
+export function Swatch({
+  name,
+  value,
+  color,
+  note,
+}: {
+  name: string;
+  value: string;
+  color: string;
+  note?: string;
+}) {
+  return (
+    <div className="token">
+      <div
+        className="token-chip"
+        style={{ background: color }}
+        aria-hidden
+      />
+      <div className="token-name">{name}</div>
+      <code className="token-value">{value}</code>
+      {note ? <div className="token-note">{note}</div> : null}
+    </div>
+  );
+}
+
+export function RadiusBox({ name, value }: { name: string; value: string }) {
+  return (
+    <div className="token">
+      <div className="token-radius" style={{ borderRadius: value }} aria-hidden />
+      <div className="token-name">{name}</div>
+      <code className="token-value">{value}</code>
+    </div>
+  );
+}
+
+export function ShadowBox({ name, value }: { name: string; value: string }) {
+  return (
+    <div className="token token--wide">
+      <div className="token-shadow" style={{ boxShadow: value }} aria-hidden />
+      <div className="token-name">{name}</div>
+      <code className="token-value token-value--block">{value}</code>
+    </div>
+  );
+}
+
+export function Type({
+  name,
+  sample = 'Form follows functionality',
+  font = 'sans',
+  size,
+  weight,
+  note,
+}: {
+  name: string;
+  sample?: string;
+  font?: 'sans' | 'handwritten' | 'mono';
+  size?: string;
+  weight?: number | string;
+  note?: string;
+}) {
+  const fontFamily =
+    font === 'handwritten'
+      ? "var(--font-homemade-apple), 'Homemade Apple', cursive"
+      : font === 'mono'
+        ? "'JetBrains Mono', monospace"
+        : "var(--font-archivo), 'Archivo', sans-serif";
+  return (
+    <div className="type-specimen">
+      <div className="type-specimen-meta">
+        <span className="type-specimen-name">{name}</span>
+        <code className="token-value">
+          {[size, weight ? `weight ${weight}` : null, font].filter(Boolean).join(' · ')}
+        </code>
+        {note ? <span className="token-note">{note}</span> : null}
+      </div>
+      <div
+        className="type-specimen-sample"
+        style={{ fontFamily, fontSize: size, fontWeight: weight as number }}
+      >
+        {sample}
+      </div>
+    </div>
+  );
+}

--- a/app/system/layout.tsx
+++ b/app/system/layout.tsx
@@ -1,0 +1,31 @@
+import type { Metadata } from 'next';
+import { Archivo, Homemade_Apple } from 'next/font/google';
+
+const archivo = Archivo({
+  subsets: ['latin'],
+  weight: ['400', '500', '600', '700', '800'],
+  variable: '--font-archivo',
+});
+
+const homemadeApple = Homemade_Apple({
+  subsets: ['latin'],
+  weight: ['400'],
+  variable: '--font-homemade-apple',
+});
+
+export const metadata: Metadata = {
+  title: 'Design System — Maximillian Piras',
+};
+
+export default function SystemLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className={`system-layout ${archivo.variable} ${homemadeApple.variable}`}>
+      <div className="system-logo">
+        <a href="/" aria-label="Back to maximin.design">
+          <img src="/assets/Sig2026.gif" alt="MXMLLN" width={100} height={100} />
+        </a>
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/app/system/page.tsx
+++ b/app/system/page.tsx
@@ -1,0 +1,95 @@
+import fs from 'fs';
+import path from 'path';
+import matter from 'gray-matter';
+import type { Metadata } from 'next';
+import { MDXRemote } from 'next-mdx-remote/rsc';
+import type { MDXComponents } from 'mdx/types';
+import Minimap from '../blog/Minimap';
+import { BlurFade } from '@/registry/ui/blur-fade';
+import { AnimatedShinyText } from '@/registry/magicui/AnimatedShinyText';
+import { MorphingText } from '@/registry/magicui/morphing-text';
+import { TextAnimate } from '@/registry/magicui/TextAnimate';
+import {
+  Swatches,
+  Swatch,
+  RadiusBox,
+  ShadowBox,
+  Type,
+} from './components/TokenSwatch';
+import { ComponentPreview } from './components/ComponentPreview';
+import './system.css';
+
+// Unlisted reference page: live at /system, but kept out of search + AI crawlers.
+export const metadata: Metadata = {
+  title: 'Design System — Maximillian Piras',
+  description: 'Internal reference for the tokens, components, and patterns behind maximin.design.',
+  robots: { index: false, follow: false },
+};
+
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^\w\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .trim();
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function HeadingWithId(Tag: 'h2' | 'h3') {
+  return function Heading(props: any) {
+    const text =
+      typeof props.children === 'string' ? props.children : String(props.children);
+    return <Tag id={slugify(text)} {...props} />;
+  };
+}
+
+const mdxComponents: MDXComponents = {
+  h2: HeadingWithId('h2'),
+  h3: HeadingWithId('h3'),
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  a: ({ href, children, ...rest }: any) => {
+    const isExternal = (href || '').startsWith('http') || (href || '').startsWith('//');
+    return (
+      <a
+        href={href}
+        {...(isExternal ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
+        {...rest}
+      >
+        {children}
+      </a>
+    );
+  },
+  // Doc helpers
+  Swatches,
+  Swatch,
+  RadiusBox,
+  ShadowBox,
+  Type,
+  ComponentPreview,
+  // Live registry components (so the doc previews real, runnable code)
+  BlurFade,
+  AnimatedShinyText,
+  MorphingText,
+  TextAnimate,
+};
+
+export default function SystemPage() {
+  const filePath = path.join(process.cwd(), 'content', 'system.mdx');
+  const raw = fs.readFileSync(filePath, 'utf-8');
+  const { data, content } = matter(raw);
+
+  return (
+    <article className="system-page">
+      <Minimap selector=".system-prose h2[id], .system-prose h3[id]" />
+      <header className="system-header">
+        <div className="system-header-eyebrow">{data.eyebrow ?? 'Design System'}</div>
+        <h1>{data.title ?? 'Design System'}</h1>
+        {data.description ? <p className="system-header-desc">{data.description}</p> : null}
+      </header>
+      <div className="system-prose">
+        <MDXRemote source={content} components={mdxComponents} />
+      </div>
+    </article>
+  );
+}

--- a/app/system/page.tsx
+++ b/app/system/page.tsx
@@ -13,6 +13,7 @@ import {
   Type,
 } from './components/TokenSwatch';
 import { ComponentPreview } from './components/ComponentPreview';
+import { NavDemo, MinimapDemo } from './components/ChromeDemos';
 import './system.css';
 
 // Unlisted reference page: live at /system, but kept out of search + AI crawlers.
@@ -63,6 +64,8 @@ const mdxComponents: MDXComponents = {
   ShadowBox,
   Type,
   ComponentPreview,
+  NavDemo,
+  MinimapDemo,
 };
 
 export default function SystemPage() {

--- a/app/system/page.tsx
+++ b/app/system/page.tsx
@@ -5,10 +5,6 @@ import type { Metadata } from 'next';
 import { MDXRemote } from 'next-mdx-remote/rsc';
 import type { MDXComponents } from 'mdx/types';
 import Minimap from '../blog/Minimap';
-import { BlurFade } from '@/registry/ui/blur-fade';
-import { AnimatedShinyText } from '@/registry/magicui/AnimatedShinyText';
-import { MorphingText } from '@/registry/magicui/morphing-text';
-import { TextAnimate } from '@/registry/magicui/TextAnimate';
 import {
   Swatches,
   Swatch,
@@ -67,11 +63,6 @@ const mdxComponents: MDXComponents = {
   ShadowBox,
   Type,
   ComponentPreview,
-  // Live registry components (so the doc previews real, runnable code)
-  BlurFade,
-  AnimatedShinyText,
-  MorphingText,
-  TextAnimate,
 };
 
 export default function SystemPage() {

--- a/app/system/system.css
+++ b/app/system/system.css
@@ -271,6 +271,46 @@
   padding: 0;
 }
 
+/* ─── Chrome demos (static replicas for previews) ────────── */
+/* Mirrors .blog-nav values, minus position:fixed so it sits in a canvas. */
+.nav-demo {
+  display: flex;
+  align-items: center;
+  height: 52px;
+  border-radius: 40px;
+  backdrop-filter: blur(80px);
+  -webkit-backdrop-filter: blur(80px);
+  background-color: rgba(240, 240, 240, 0.65);
+  box-shadow: 0 3px 30px rgba(0, 0, 0, 0.15);
+  border: solid 2px rgba(0, 0, 0, 0.1);
+  padding: 0 8px;
+  gap: 2px;
+}
+.nav-demo a {
+  font-family: var(--font-archivo), 'Archivo', sans-serif;
+  font-weight: 600;
+  font-size: 13px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  color: #1a1a1a;
+  padding: 12px 16px;
+  border-radius: 40px;
+  opacity: 0.5;
+}
+.nav-demo a.active {
+  background-color: #fff;
+  opacity: 1;
+}
+
+/* Static minimap replica (real one is position:fixed). */
+.minimap-demo {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 6px;
+  padding: 8px 6px;
+}
+
 /* ─── Minimap (shared visual language with /blog) ────────── */
 .minimap {
   position: fixed;

--- a/app/system/system.css
+++ b/app/system/system.css
@@ -212,23 +212,39 @@
   border-radius: 16px;
   overflow: hidden;
 }
-.component-preview-head {
+.component-preview-tabs {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  padding: 12px 16px;
+  gap: 4px;
+  padding: 8px 12px;
   border-bottom: 1px solid #e5e7eb;
   background: #fafafa;
 }
-.component-preview-title {
+.component-preview-tabs button {
+  font-family: inherit;
   font-size: 13px;
   font-weight: 600;
+  color: #999;
+  background: none;
+  border: none;
+  padding: 6px 12px;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: color 0.15s, background 0.15s;
+}
+.component-preview-tabs button:hover {
+  color: #1a1a1a;
+}
+.component-preview-tabs button.is-active {
+  color: #1a1a1a;
+  background: #fff;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
 }
 .component-preview-source {
+  margin-left: auto;
   font-family: 'JetBrains Mono', monospace;
   font-size: 11px;
-  color: #999;
+  color: #bbb;
   background: none;
   padding: 0;
 }
@@ -292,23 +308,35 @@
   font-size: 13px;
   letter-spacing: 1px;
   text-transform: uppercase;
+  text-decoration: none;
   color: #1a1a1a;
   padding: 12px 16px;
   border-radius: 40px;
   opacity: 0.5;
+  cursor: pointer;
+  transition: opacity 0.3s ease, background-color 0.3s ease;
+}
+.nav-demo a:hover {
+  opacity: 0.75;
 }
 .nav-demo a.active {
   background-color: #fff;
   opacity: 1;
 }
 
-/* Static minimap replica (real one is position:fixed). */
-.minimap-demo {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  gap: 6px;
-  padding: 8px 6px;
+/* Minimap demo: real popover behavior, scoped (real one is position:fixed). */
+.minimap-demo-wrap {
+  position: relative;
+  display: inline-flex;
+}
+
+/* Logo demo: hint at the article-page scroll-spin on hover. */
+.logo-demo {
+  cursor: pointer;
+  transition: transform 0.8s cubic-bezier(0.4, 0, 0.2, 1);
+}
+.logo-demo:hover {
+  transform: rotate(360deg);
 }
 
 /* ─── Minimap (shared visual language with /blog) ────────── */

--- a/app/system/system.css
+++ b/app/system/system.css
@@ -212,42 +212,6 @@
   border-radius: 16px;
   overflow: hidden;
 }
-.component-preview-tabs {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  padding: 8px 12px;
-  border-bottom: 1px solid #e5e7eb;
-  background: #fafafa;
-}
-.component-preview-tabs button {
-  font-family: inherit;
-  font-size: 13px;
-  font-weight: 600;
-  color: #999;
-  background: none;
-  border: none;
-  padding: 6px 12px;
-  border-radius: 8px;
-  cursor: pointer;
-  transition: color 0.15s, background 0.15s;
-}
-.component-preview-tabs button:hover {
-  color: #1a1a1a;
-}
-.component-preview-tabs button.is-active {
-  color: #1a1a1a;
-  background: #fff;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
-}
-.component-preview-source {
-  margin-left: auto;
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 11px;
-  color: #bbb;
-  background: none;
-  padding: 0;
-}
 .component-preview-canvas {
   display: flex;
   align-items: center;
@@ -287,20 +251,6 @@
   min-height: 280px;
   align-items: flex-start;
   padding-top: 28px;
-}
-.component-preview-code {
-  margin: 0;
-  padding: 16px 20px;
-  background: #1a1a1a;
-  overflow-x: auto;
-}
-.component-preview-code code {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 13px;
-  line-height: 1.6;
-  color: #e0e0e0;
-  background: none;
-  padding: 0;
 }
 
 /* ─── Chrome demos (static replicas for previews) ────────── */

--- a/app/system/system.css
+++ b/app/system/system.css
@@ -314,7 +314,7 @@
   border-radius: 40px;
   opacity: 0.5;
   cursor: pointer;
-  transition: opacity 0.3s ease, background-color 0.3s ease;
+  transition: opacity 0.3s ease;
 }
 .nav-demo a:hover {
   opacity: 0.75;
@@ -328,6 +328,14 @@
 .minimap-demo-wrap {
   position: relative;
   display: inline-flex;
+}
+/* Real component darkens idle notches on rail hover via .minimap:hover —
+   replicate it for the scoped wrapper. */
+.minimap-demo-wrap:hover .minimap-notch {
+  background: #999;
+}
+.minimap-demo-wrap:hover .minimap-notch--active {
+  background: #1a1a1a;
 }
 
 /* Logo demo: hint at the article-page scroll-spin on hover. */

--- a/app/system/system.css
+++ b/app/system/system.css
@@ -272,6 +272,22 @@
   background-size: 16px 16px;
   background-position: 0 0, 0 8px, 8px -8px, -8px 0;
 }
+/* Colorful blobs behind glass chrome so backdrop-filter: blur() is visible. */
+.component-preview-canvas--glass {
+  background-color: #f4f4f5;
+  background-image:
+    radial-gradient(circle at 18% 28%, rgba(255, 86, 120, 0.55), transparent 42%),
+    radial-gradient(circle at 82% 22%, rgba(70, 140, 255, 0.55), transparent 42%),
+    radial-gradient(circle at 68% 82%, rgba(96, 214, 150, 0.5), transparent 42%),
+    radial-gradient(circle at 28% 78%, rgba(255, 196, 64, 0.5), transparent 42%);
+}
+/* Top-aligned, taller canvas so left/downward popovers aren't clipped by the
+   card's overflow:hidden. */
+.component-preview-canvas--tall {
+  min-height: 280px;
+  align-items: flex-start;
+  padding-top: 28px;
+}
 .component-preview-code {
   margin: 0;
   padding: 16px 20px;

--- a/app/system/system.css
+++ b/app/system/system.css
@@ -1,0 +1,371 @@
+@import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&display=swap');
+
+.system-layout {
+  min-height: 100vh;
+  background: #fff;
+  color: #1a1a1a;
+  font-family: var(--font-archivo), 'Archivo', sans-serif;
+}
+
+/* Logo — fixed, links home */
+.system-logo {
+  position: fixed;
+  top: 24px;
+  left: 24px;
+  z-index: 100;
+  mix-blend-mode: difference;
+}
+.system-logo a {
+  display: block;
+  line-height: 0;
+  transition: opacity 0.3s ease;
+}
+.system-logo a:hover {
+  opacity: 0.6;
+}
+.system-logo img {
+  filter: invert(1) contrast(1000);
+}
+
+/* Page shell */
+.system-page {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 48px 24px 96px;
+}
+
+.system-header {
+  margin-bottom: 56px;
+  padding-bottom: 40px;
+  border-bottom: 1px solid #e0e0e0;
+}
+.system-header-eyebrow {
+  font-family: var(--font-homemade-apple), 'Homemade Apple', cursive;
+  font-weight: 500;
+  font-size: 20px;
+  color: #1a1a1a;
+  margin-bottom: 6px;
+}
+.system-header h1 {
+  font-family: var(--font-archivo), 'Archivo', sans-serif;
+  font-weight: 800;
+  font-size: 44px;
+  line-height: 1.1;
+  letter-spacing: -0.5px;
+  margin: 0;
+}
+.system-header-desc {
+  font-size: 17px;
+  line-height: 1.6;
+  color: #666;
+  margin: 16px 0 0;
+  max-width: 60ch;
+}
+
+/* Prose — mirrors .blog-prose so MDX reads consistently */
+.system-prose {
+  font-size: 16px;
+  line-height: 1.75;
+  color: #333;
+}
+.system-prose > *:last-child {
+  margin-bottom: 0;
+}
+.system-prose h2 {
+  font-size: 28px;
+  font-weight: 700;
+  margin: 64px 0 16px;
+  letter-spacing: -0.3px;
+  scroll-margin-top: 32px;
+}
+.system-prose h3 {
+  font-size: 20px;
+  font-weight: 600;
+  margin: 40px 0 12px;
+  scroll-margin-top: 32px;
+}
+.system-prose p {
+  margin: 0 0 24px;
+}
+.system-prose a {
+  color: #1a1a1a;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  transition: opacity 0.2s;
+}
+.system-prose a:hover {
+  opacity: 0.6;
+}
+.system-prose strong {
+  font-weight: 600;
+}
+.system-prose ul,
+.system-prose ol {
+  margin: 0 0 24px;
+  padding-left: 1.5em;
+}
+.system-prose ul {
+  list-style-type: disc;
+}
+.system-prose ol {
+  list-style-type: decimal;
+}
+.system-prose li {
+  margin-bottom: 8px;
+}
+.system-prose code {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.875em;
+  background: #f5f5f5;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+.system-prose hr {
+  border: none;
+  border-top: 1px solid #e0e0e0;
+  margin: 56px 0;
+}
+
+/* ─── Token grid ─────────────────────────────────────────── */
+.token-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 16px;
+  margin: 8px 0 32px;
+}
+.token {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.token--wide {
+  grid-column: 1 / -1;
+}
+.token-chip {
+  width: 100%;
+  aspect-ratio: 3 / 2;
+  border-radius: 10px;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+}
+.token-radius {
+  width: 100%;
+  aspect-ratio: 3 / 2;
+  background: #1a1a1a;
+}
+.token-shadow {
+  width: 100%;
+  height: 72px;
+  background: #fff;
+  border-radius: 12px;
+  margin-bottom: 4px;
+}
+.token-name {
+  font-size: 13px;
+  font-weight: 600;
+  color: #1a1a1a;
+}
+.token-value {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 12px;
+  color: #666;
+  background: #f5f5f5;
+  padding: 2px 6px;
+  border-radius: 4px;
+  align-self: flex-start;
+}
+.token-value--block {
+  align-self: stretch;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+.token-note {
+  font-size: 12px;
+  color: #999;
+  line-height: 1.4;
+}
+
+/* ─── Type specimens ─────────────────────────────────────── */
+.type-specimen {
+  padding: 20px 0;
+  border-bottom: 1px solid #f0f0f0;
+}
+.type-specimen-meta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-bottom: 10px;
+}
+.type-specimen-name {
+  font-size: 13px;
+  font-weight: 600;
+}
+.type-specimen-sample {
+  color: #1a1a1a;
+  line-height: 1.2;
+}
+
+/* ─── Component preview ──────────────────────────────────── */
+.component-preview {
+  margin: 24px 0 40px;
+  border: 1px solid #e5e7eb;
+  border-radius: 16px;
+  overflow: hidden;
+}
+.component-preview-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 16px;
+  border-bottom: 1px solid #e5e7eb;
+  background: #fafafa;
+}
+.component-preview-title {
+  font-size: 13px;
+  font-weight: 600;
+}
+.component-preview-source {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  color: #999;
+  background: none;
+  padding: 0;
+}
+.component-preview-canvas {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 160px;
+  padding: 40px 24px;
+}
+.component-preview-canvas--light {
+  background: #fff;
+}
+.component-preview-canvas--dark {
+  background: #1a1a1a;
+  color: #fff;
+}
+.component-preview-canvas--checker {
+  background-color: #fafafa;
+  background-image:
+    linear-gradient(45deg, #f0f0f0 25%, transparent 25%),
+    linear-gradient(-45deg, #f0f0f0 25%, transparent 25%),
+    linear-gradient(45deg, transparent 75%, #f0f0f0 75%),
+    linear-gradient(-45deg, transparent 75%, #f0f0f0 75%);
+  background-size: 16px 16px;
+  background-position: 0 0, 0 8px, 8px -8px, -8px 0;
+}
+.component-preview-code {
+  margin: 0;
+  padding: 16px 20px;
+  background: #1a1a1a;
+  overflow-x: auto;
+}
+.component-preview-code code {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 13px;
+  line-height: 1.6;
+  color: #e0e0e0;
+  background: none;
+  padding: 0;
+}
+
+/* ─── Minimap (shared visual language with /blog) ────────── */
+.minimap {
+  position: fixed;
+  top: 24px;
+  right: 24px;
+  z-index: 100;
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+}
+.minimap-notches {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 6px;
+  padding: 8px 6px;
+  cursor: pointer;
+}
+.minimap-notch {
+  width: 16px;
+  height: 2px;
+  background: #ccc;
+  border-radius: 1px;
+  transition: background 0.2s, width 0.2s;
+}
+.minimap-notch--sub {
+  width: 10px;
+}
+.minimap-notch--active {
+  background: #1a1a1a;
+}
+.minimap:hover .minimap-notch {
+  background: #999;
+}
+.minimap:hover .minimap-notch--active {
+  background: #1a1a1a;
+}
+.minimap-popover {
+  position: absolute;
+  top: 0;
+  right: 100%;
+  margin-right: 8px;
+  background: #fff;
+  border: 1px solid #e5e5e5;
+  border-radius: 8px;
+  padding: 8px 0;
+  min-width: 200px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
+  white-space: nowrap;
+}
+.minimap-link {
+  display: block;
+  padding: 6px 16px;
+  font-size: 13px;
+  color: #666;
+  text-decoration: none;
+  transition: color 0.15s, background 0.15s;
+}
+.minimap-link--sub {
+  padding-left: 28px;
+  font-size: 12px;
+}
+.minimap-link:hover {
+  color: #1a1a1a;
+  background: #f5f5f5;
+}
+.minimap-link--active {
+  color: #1a1a1a;
+  font-weight: 600;
+}
+@media (max-width: 768px) {
+  .minimap {
+    display: none;
+  }
+}
+
+/* ─── Responsive ─────────────────────────────────────────── */
+@media (max-width: 960px) {
+  .system-logo {
+    top: 10px;
+    left: 10px;
+  }
+  .system-logo img {
+    width: 76px;
+    height: 76px;
+  }
+  .system-page {
+    padding-top: 102px;
+  }
+}
+@media (max-width: 640px) {
+  .system-header h1 {
+    font-size: 30px;
+  }
+  .system-prose {
+    font-size: 15px;
+  }
+}

--- a/content/system.mdx
+++ b/content/system.mdx
@@ -104,5 +104,3 @@ Fixed right-rail table-of-contents. Renders a notch per heading (`h2` full-width
 >
   <MinimapDemo />
 </ComponentPreview>
-
-> The real `Minimap` is also live on this page — the notched rail at the right edge tracks your scroll position.

--- a/content/system.mdx
+++ b/content/system.mdx
@@ -69,14 +69,13 @@ The persistent UI that frames every long-form page (blog, this page).
 The fixed signature mark, top-left. On index pages it's the `Sig2026.gif`; on article pages it becomes a Lottie (`LogoSpin2026.json`) that spins with scroll direction. It uses `mix-blend-mode: difference` + `invert(1)` so it stays legible over any background it scrolls past. Reference: `app/blog/BlogLogo.tsx`, `app/system/layout.tsx`.
 
 <ComponentPreview
-  title="Logo"
   source="app/blog/BlogLogo.tsx"
   code={`<div className="blog-logo">
   <a href="/"><img src="/assets/Sig2026.gif" width={100} height={100} /></a>
 </div>
 // article pages swap the gif for a scroll-driven Lottie`}
 >
-  <img src="/assets/Sig2026.gif" alt="MXMLLN" width={88} height={88} />
+  <img className="logo-demo" src="/assets/Sig2026.gif" alt="MXMLLN" width={88} height={88} />
 </ComponentPreview>
 
 ### Nav bar
@@ -84,7 +83,6 @@ The fixed signature mark, top-left. On index pages it's the `Sig2026.gif`; on ar
 Floating glass pill, centered top. Uppercase Archivo links at low opacity; the active link gets a solid white fill. Reference: `.blog-nav` in `app/blog/blog.css`.
 
 <ComponentPreview
-  title="Nav bar"
   source="app/blog/blog.css → .blog-nav"
   code={`<nav className="blog-nav">
   <a className="active">Work</a>
@@ -92,11 +90,7 @@ Floating glass pill, centered top. Uppercase Archivo links at low opacity; the a
   <a>About</a>
 </nav>`}
 >
-  <nav className="nav-demo">
-    <a className="active">Work</a>
-    <a>Words</a>
-    <a>About</a>
-  </nav>
+  <NavDemo />
 </ComponentPreview>
 
 ### Minimap
@@ -104,17 +98,11 @@ Floating glass pill, centered top. Uppercase Archivo links at low opacity; the a
 Fixed right-rail table-of-contents. Renders a notch per heading (`h2` full-width, `h3` shorter), highlights the section in view via `IntersectionObserver`, and reveals a labeled popover on hover. Reference: `app/blog/Minimap.tsx` — it scans a CSS selector for headings, so it works on any prose page (this page included).
 
 <ComponentPreview
-  title="Minimap"
   source="app/blog/Minimap.tsx"
-  background="checker"
   code={`<Minimap selector=".system-prose h2[id], .system-prose h3[id]" />
 // notch per heading · active = in view · hover reveals labels`}
 >
-  <div className="minimap-demo">
-    <div className="minimap-notch" />
-    <div className="minimap-notch minimap-notch--active" />
-    <div className="minimap-notch minimap-notch--sub" />
-    <div className="minimap-notch" />
-    <div className="minimap-notch minimap-notch--sub" />
-  </div>
+  <MinimapDemo />
 </ComponentPreview>
+
+> The real `Minimap` is also live on this page — the notched rail at the right edge tracks your scroll position.

--- a/content/system.mdx
+++ b/content/system.mdx
@@ -3,7 +3,7 @@ title: Design System
 eyebrow: MVXMXM
 ---
 
-## Foundations — Color
+## Color
 
 Near-monochrome by default. Ink on white, with a small ladder of grays for borders, surfaces, and secondary text. Color is reserved for content (work samples, gradients), not chrome.
 
@@ -18,7 +18,7 @@ Near-monochrome by default. Ink on white, with a small ladder of grays for borde
   <Swatch name="Surface alt" value="#f9fafb" color="#f9fafb" note="preview canvas" />
 </Swatches>
 
-## Foundations — Typography
+## Typography
 
 Two faces do the work: **Archivo** for everything structural, and **Homemade Apple** as a handwritten accent for dates, eyebrows, and labels. **JetBrains Mono** is used only for code. Fonts are loaded via `next/font` in each layout and exposed as `--font-archivo` / `--font-homemade-apple`.
 
@@ -29,7 +29,7 @@ Two faces do the work: **Archivo** for everything structural, and **Homemade App
 <Type name="Handwritten accent" sample="words by maximillian" size="20px" weight={400} font="handwritten" note="dates, eyebrows, labels" />
 <Type name="Mono" sample="const tokens = true" size="14px" weight={400} font="mono" note="code only" />
 
-## Foundations — Radius
+## Radius
 
 Soft, generous corners. Pills (`40px`) for floating chrome, large radii for cards.
 
@@ -42,7 +42,7 @@ Soft, generous corners. Pills (`40px`) for floating chrome, large radii for card
   <RadiusBox name="Pill" value="40px" />
 </Swatches>
 
-## Foundations — Elevation
+## Elevation
 
 Shadows are soft and wide, never harsh. The glass nav combines a heavy backdrop blur with a translucent fill.
 
@@ -52,7 +52,7 @@ Shadows are soft and wide, never harsh. The glass nav combines a heavy backdrop 
   <ShadowBox name="Folio card" value="0 20px 40px rgba(0,0,0,0.08), inset 0 0 0 1px rgba(0,0,0,0.04)" />
 </Swatches>
 
-## Foundations — Motion
+## Motion
 
 Almost everything eases between `0.2s` and `0.5s`. `FolioEngine` uses `0.35s ease` as its house transition; text effects use `cubic-bezier(0.4, 0, 0.2, 1)`. Motion is built on **framer-motion** via the `registry/` primitives below — prefer those over hand-rolled keyframes.
 

--- a/content/system.mdx
+++ b/content/system.mdx
@@ -1,0 +1,166 @@
+---
+title: Design System
+eyebrow: Reference for humans & agents
+description: The tokens, type, components, and patterns behind maximin.design. This file is the single source of truth — edit it here and the /system page updates. globals.css is the canonical definition for tokens; this doc documents and previews them.
+---
+
+This is an internal, unlisted reference — it isn't linked from the site nav, and it's set to `noindex`. It exists so that **coding agents** (and future-me) have one place to learn how the site is built before designing or generating new UI.
+
+**For agents:** the canonical token definitions live in `app/globals.css` (`:root` + `@theme`). Components live in `registry/`. This document mirrors and explains them; when they disagree, the code wins — update this file to match.
+
+## Foundations — Color
+
+Near-monochrome by default. Ink on white, with a small ladder of grays for borders, surfaces, and secondary text. Color is reserved for content (work samples, gradients), not chrome.
+
+<Swatches>
+  <Swatch name="Background" value="#ffffff" color="#ffffff" note="--background" />
+  <Swatch name="Foreground / Ink" value="#1a1a1a" color="#1a1a1a" note="--foreground" />
+  <Swatch name="Muted text" value="#666666" color="#666666" note="captions, descriptions" />
+  <Swatch name="Subtle text" value="#999999" color="#999999" note="metadata, figcaptions" />
+  <Swatch name="Hairline" value="#e0e0e0" color="#e0e0e0" note="rules, dividers" />
+  <Swatch name="Border" value="#e5e7eb" color="#e5e7eb" note="cards, previews" />
+  <Swatch name="Surface" value="#f5f5f5" color="#f5f5f5" note="code, chips" />
+  <Swatch name="Surface alt" value="#f9fafb" color="#f9fafb" note="preview canvas" />
+</Swatches>
+
+## Foundations — Typography
+
+Two faces do the work: **Archivo** for everything structural, and **Homemade Apple** as a handwritten accent for dates, eyebrows, and labels. **JetBrains Mono** is used only for code. Fonts are loaded via `next/font` in each layout and exposed as `--font-archivo` / `--font-homemade-apple`.
+
+<Type name="Display" sample="Form follows functionality." size="48px" weight={800} font="sans" note="hero titles" />
+<Type name="H1" sample="Form follows functionality." size="40px" weight={800} font="sans" />
+<Type name="H2" sample="Section heading" size="28px" weight={700} font="sans" />
+<Type name="Body" sample="The quick brown fox jumps over the lazy dog." size="16px" weight={400} font="sans" note="line-height 1.75" />
+<Type name="Handwritten accent" sample="words by maximillian" size="20px" weight={400} font="handwritten" note="dates, eyebrows, labels" />
+<Type name="Mono" sample="const tokens = true" size="14px" weight={400} font="mono" note="code only" />
+
+## Foundations — Radius
+
+Soft, generous corners. Pills (`40px`) for floating chrome, large radii for cards.
+
+<Swatches>
+  <RadiusBox name="Chip / input" value="6px" />
+  <RadiusBox name="Code / small" value="8px" />
+  <RadiusBox name="Card" value="16px" />
+  <RadiusBox name="Card (folio)" value="24px" />
+  <RadiusBox name="Hero card" value="36px" />
+  <RadiusBox name="Pill" value="40px" />
+</Swatches>
+
+## Foundations — Elevation
+
+Shadows are soft and wide, never harsh. The glass nav combines a heavy backdrop blur with a translucent fill.
+
+<Swatches>
+  <ShadowBox name="Card hover" value="0 12px 24px rgba(0,0,0,0.08)" />
+  <ShadowBox name="Glass nav" value="0 3px 30px rgba(0,0,0,0.15)" />
+  <ShadowBox name="Folio card" value="0 20px 40px rgba(0,0,0,0.08), inset 0 0 0 1px rgba(0,0,0,0.04)" />
+</Swatches>
+
+## Foundations — Motion
+
+Almost everything eases between `0.2s` and `0.5s`. `FolioEngine` uses `0.35s ease` as its house transition; text effects use `cubic-bezier(0.4, 0, 0.2, 1)`. Motion is built on **framer-motion** via the `registry/` primitives below — prefer those over hand-rolled keyframes.
+
+- **Standard transition:** `all 0.35s ease`
+- **Quick (hover/opacity):** `0.2s ease`
+- **Easing curve:** `cubic-bezier(0.4, 0, 0.2, 1)`
+
+## Components
+
+Reusable primitives live in `registry/`. They're client components (`"use client"`) built on framer-motion. Previews below run the real code.
+
+### BlurFade
+
+Fades + slides content in, optionally when scrolled into view. `registry/ui/blur-fade.tsx`.
+
+<ComponentPreview
+  title="BlurFade"
+  source="registry/ui/blur-fade.tsx"
+  code={`<BlurFade inView direction="up">
+  Designed to amplify human capability.
+</BlurFade>`}
+>
+  <BlurFade inView direction="up">
+    <span style={{ fontSize: 24, fontWeight: 700 }}>
+      Designed to amplify human capability.
+    </span>
+  </BlurFade>
+</ComponentPreview>
+
+Props: `direction` (`up`/`down`/`left`/`right`), `delay`, `duration`, `offset`, `blur`, `inView`.
+
+### TextAnimate
+
+Word-by-word blur-in for headings. `registry/magicui/TextAnimate.tsx`.
+
+<ComponentPreview
+  title="TextAnimate"
+  source="registry/magicui/TextAnimate.tsx"
+  code={`<TextAnimate animation="blurInUp" as="h2">
+  Form follows functionality
+</TextAnimate>`}
+>
+  <TextAnimate animation="blurInUp" as="span">
+    <span style={{ fontSize: 28, fontWeight: 700 }}>Form follows functionality</span>
+  </TextAnimate>
+</ComponentPreview>
+
+Props: `animation` (`blurIn`/`blurInUp`), `as` (element tag). Strings animate per-word; other children animate as one block.
+
+### MorphingText
+
+Cross-fades + blurs between values when the keyed child changes. `registry/magicui/morphing-text.tsx`.
+
+<ComponentPreview
+  title="MorphingText"
+  source="registry/magicui/morphing-text.tsx"
+  code={`<MorphingText>{label}</MorphingText>
+// re-renders with a new child morph between states`}
+>
+  <MorphingText>
+    <span style={{ fontSize: 28, fontWeight: 700 }}>Morphing</span>
+  </MorphingText>
+</ComponentPreview>
+
+The morph triggers on `key` change (`key={String(children)}`), so feed it changing text.
+
+### AnimatedShinyText
+
+> **Note:** currently a passthrough stub — it renders a `<span>` with the given `className` and no shimmer yet. Documented here so its intended role (shimmering accent text) is tracked. Flesh out the animation in `registry/magicui/AnimatedShinyText.tsx` before relying on it.
+
+<ComponentPreview
+  title="AnimatedShinyText"
+  source="registry/magicui/AnimatedShinyText.tsx"
+  code={`<AnimatedShinyText>Coming soon</AnimatedShinyText>`}
+>
+  <AnimatedShinyText><span style={{ fontSize: 20, color: '#999' }}>Coming soon</span></AnimatedShinyText>
+</ComponentPreview>
+
+## Patterns
+
+Recurring recipes that aren't single components.
+
+### Glassmorphism chrome
+
+Floating nav/panels use a heavy backdrop blur over a translucent light fill with a hairline border. Reference: `.blog-nav`.
+
+```css
+backdrop-filter: blur(80px);
+-webkit-backdrop-filter: blur(80px);
+background-color: rgba(240, 240, 240, 0.65);
+box-shadow: 0 3px 30px rgba(0, 0, 0, 0.15);
+border: solid 2px rgba(0, 0, 0, 0.1);
+border-radius: 40px;
+```
+
+### Mix-blend logo
+
+The fixed logo uses `mix-blend-mode: difference` (and `invert(1)` on the mark) so it stays legible over any background it scrolls past. Reference: `.blog-logo`, `.system-logo`.
+
+### Card stacks (FolioEngine)
+
+The portfolio's signature interaction. Cards are absolutely positioned with calculated z-index, randomized rotations (stored per-stack in a `Map`), and negative margins (`-160px`) to create the stacked look. All states are inline styles transitioned at `0.35s ease`, not CSS classes. See `public/components/FolioEngine.js` and `CLAUDE.md` for the expand/collapse flow.
+
+### Content column
+
+Long-form pages (blog, this page) use a centered column — `max-width: 700–760px`, `padding: 48px 24px 80px` — with a fixed `Minimap` for in-page navigation and the fixed logo top-left.

--- a/content/system.mdx
+++ b/content/system.mdx
@@ -84,6 +84,7 @@ Floating glass pill, centered top. Uppercase Archivo links at low opacity; the a
 
 <ComponentPreview
   source="app/blog/blog.css → .blog-nav"
+  background="glass"
   code={`<nav className="blog-nav">
   <a className="active">Work</a>
   <a>Words</a>
@@ -99,6 +100,7 @@ Fixed right-rail table-of-contents. Renders a notch per heading (`h2` full-width
 
 <ComponentPreview
   source="app/blog/Minimap.tsx"
+  tall
   code={`<Minimap selector=".system-prose h2[id], .system-prose h3[id]" />
 // notch per heading · active = in view · hover reveals labels`}
 >

--- a/content/system.mdx
+++ b/content/system.mdx
@@ -3,8 +3,6 @@ title: Design System
 eyebrow: MVXMXM
 ---
 
-**For agents:** the canonical token definitions live in `app/globals.css` (`:root` + `@theme`). This document mirrors and explains them; when they disagree, the code wins — update this file to match.
-
 ## Foundations — Color
 
 Near-monochrome by default. Ink on white, with a small ladder of grays for borders, surfaces, and secondary text. Color is reserved for content (work samples, gradients), not chrome.

--- a/content/system.mdx
+++ b/content/system.mdx
@@ -60,7 +60,7 @@ Almost everything eases between `0.2s` and `0.5s`. `FolioEngine` uses `0.35s eas
 - **Quick (hover/opacity):** `0.2s ease`
 - **Easing curve:** `cubic-bezier(0.4, 0, 0.2, 1)`
 
-## Components — Chrome
+## Components
 
 The persistent UI that frames every long-form page (blog, this page).
 
@@ -117,77 +117,4 @@ Fixed right-rail table-of-contents. Renders a notch per heading (`h2` full-width
     <div className="minimap-notch" />
     <div className="minimap-notch minimap-notch--sub" />
   </div>
-</ComponentPreview>
-
-## Motion primitives
-
-> **Status:** these live in `registry/` (added from [magicui](https://magicui.design), a shadcn-style component set) but are **not currently used anywhere on the site**. They're available primitives, not established components — wire them in or delete them. Documented here so the inventory is honest.
-
-They're client components (`"use client"`) built on framer-motion. Previews below run the real code.
-
-### BlurFade
-
-Fades + slides content in, optionally when scrolled into view. `registry/ui/blur-fade.tsx`.
-
-<ComponentPreview
-  title="BlurFade"
-  source="registry/ui/blur-fade.tsx"
-  code={`<BlurFade inView direction="up">
-  Designed to amplify human capability.
-</BlurFade>`}
->
-  <BlurFade inView direction="up">
-    <span style={{ fontSize: 24, fontWeight: 700 }}>
-      Designed to amplify human capability.
-    </span>
-  </BlurFade>
-</ComponentPreview>
-
-Props: `direction` (`up`/`down`/`left`/`right`), `delay`, `duration`, `offset`, `blur`, `inView`.
-
-### TextAnimate
-
-Word-by-word blur-in for headings. `registry/magicui/TextAnimate.tsx`.
-
-<ComponentPreview
-  title="TextAnimate"
-  source="registry/magicui/TextAnimate.tsx"
-  code={`<TextAnimate animation="blurInUp" as="h2">
-  Form follows functionality
-</TextAnimate>`}
->
-  <TextAnimate animation="blurInUp" as="span">
-    <span style={{ fontSize: 28, fontWeight: 700 }}>Form follows functionality</span>
-  </TextAnimate>
-</ComponentPreview>
-
-Props: `animation` (`blurIn`/`blurInUp`), `as` (element tag). Strings animate per-word; other children animate as one block.
-
-### MorphingText
-
-Cross-fades + blurs between values when the keyed child changes. `registry/magicui/morphing-text.tsx`.
-
-<ComponentPreview
-  title="MorphingText"
-  source="registry/magicui/morphing-text.tsx"
-  code={`<MorphingText>{label}</MorphingText>
-// re-renders with a new child morph between states`}
->
-  <MorphingText>
-    <span style={{ fontSize: 28, fontWeight: 700 }}>Morphing</span>
-  </MorphingText>
-</ComponentPreview>
-
-The morph triggers on `key` change (`key={String(children)}`), so feed it changing text.
-
-### AnimatedShinyText
-
-> **Note:** currently a passthrough stub — it renders a `<span>` with the given `className` and no shimmer yet. Documented here so its intended role (shimmering accent text) is tracked. Flesh out the animation in `registry/magicui/AnimatedShinyText.tsx` before relying on it.
-
-<ComponentPreview
-  title="AnimatedShinyText"
-  source="registry/magicui/AnimatedShinyText.tsx"
-  code={`<AnimatedShinyText>Coming soon</AnimatedShinyText>`}
->
-  <AnimatedShinyText><span style={{ fontSize: 20, color: '#999' }}>Coming soon</span></AnimatedShinyText>
 </ComponentPreview>

--- a/content/system.mdx
+++ b/content/system.mdx
@@ -1,12 +1,9 @@
 ---
 title: Design System
-eyebrow: Reference for humans & agents
-description: The tokens, type, components, and patterns behind maximin.design. This file is the single source of truth — edit it here and the /system page updates. globals.css is the canonical definition for tokens; this doc documents and previews them.
+eyebrow: MVXMXM
 ---
 
-This is an internal, unlisted reference — it isn't linked from the site nav, and it's set to `noindex`. It exists so that **coding agents** (and future-me) have one place to learn how the site is built before designing or generating new UI.
-
-**For agents:** the canonical token definitions live in `app/globals.css` (`:root` + `@theme`). Components live in `registry/`. This document mirrors and explains them; when they disagree, the code wins — update this file to match.
+**For agents:** the canonical token definitions live in `app/globals.css` (`:root` + `@theme`). This document mirrors and explains them; when they disagree, the code wins — update this file to match.
 
 ## Foundations — Color
 
@@ -65,9 +62,70 @@ Almost everything eases between `0.2s` and `0.5s`. `FolioEngine` uses `0.35s eas
 - **Quick (hover/opacity):** `0.2s ease`
 - **Easing curve:** `cubic-bezier(0.4, 0, 0.2, 1)`
 
-## Components
+## Components — Chrome
 
-Reusable primitives live in `registry/`. They're client components (`"use client"`) built on framer-motion. Previews below run the real code.
+The persistent UI that frames every long-form page (blog, this page).
+
+### Logo
+
+The fixed signature mark, top-left. On index pages it's the `Sig2026.gif`; on article pages it becomes a Lottie (`LogoSpin2026.json`) that spins with scroll direction. It uses `mix-blend-mode: difference` + `invert(1)` so it stays legible over any background it scrolls past. Reference: `app/blog/BlogLogo.tsx`, `app/system/layout.tsx`.
+
+<ComponentPreview
+  title="Logo"
+  source="app/blog/BlogLogo.tsx"
+  code={`<div className="blog-logo">
+  <a href="/"><img src="/assets/Sig2026.gif" width={100} height={100} /></a>
+</div>
+// article pages swap the gif for a scroll-driven Lottie`}
+>
+  <img src="/assets/Sig2026.gif" alt="MXMLLN" width={88} height={88} />
+</ComponentPreview>
+
+### Nav bar
+
+Floating glass pill, centered top. Uppercase Archivo links at low opacity; the active link gets a solid white fill. Reference: `.blog-nav` in `app/blog/blog.css`.
+
+<ComponentPreview
+  title="Nav bar"
+  source="app/blog/blog.css → .blog-nav"
+  code={`<nav className="blog-nav">
+  <a className="active">Work</a>
+  <a>Words</a>
+  <a>About</a>
+</nav>`}
+>
+  <nav className="nav-demo">
+    <a className="active">Work</a>
+    <a>Words</a>
+    <a>About</a>
+  </nav>
+</ComponentPreview>
+
+### Minimap
+
+Fixed right-rail table-of-contents. Renders a notch per heading (`h2` full-width, `h3` shorter), highlights the section in view via `IntersectionObserver`, and reveals a labeled popover on hover. Reference: `app/blog/Minimap.tsx` — it scans a CSS selector for headings, so it works on any prose page (this page included).
+
+<ComponentPreview
+  title="Minimap"
+  source="app/blog/Minimap.tsx"
+  background="checker"
+  code={`<Minimap selector=".system-prose h2[id], .system-prose h3[id]" />
+// notch per heading · active = in view · hover reveals labels`}
+>
+  <div className="minimap-demo">
+    <div className="minimap-notch" />
+    <div className="minimap-notch minimap-notch--active" />
+    <div className="minimap-notch minimap-notch--sub" />
+    <div className="minimap-notch" />
+    <div className="minimap-notch minimap-notch--sub" />
+  </div>
+</ComponentPreview>
+
+## Motion primitives
+
+> **Status:** these live in `registry/` (added from [magicui](https://magicui.design), a shadcn-style component set) but are **not currently used anywhere on the site**. They're available primitives, not established components — wire them in or delete them. Documented here so the inventory is honest.
+
+They're client components (`"use client"`) built on framer-motion. Previews below run the real code.
 
 ### BlurFade
 
@@ -135,32 +193,3 @@ The morph triggers on `key` change (`key={String(children)}`), so feed it changi
 >
   <AnimatedShinyText><span style={{ fontSize: 20, color: '#999' }}>Coming soon</span></AnimatedShinyText>
 </ComponentPreview>
-
-## Patterns
-
-Recurring recipes that aren't single components.
-
-### Glassmorphism chrome
-
-Floating nav/panels use a heavy backdrop blur over a translucent light fill with a hairline border. Reference: `.blog-nav`.
-
-```css
-backdrop-filter: blur(80px);
--webkit-backdrop-filter: blur(80px);
-background-color: rgba(240, 240, 240, 0.65);
-box-shadow: 0 3px 30px rgba(0, 0, 0, 0.15);
-border: solid 2px rgba(0, 0, 0, 0.1);
-border-radius: 40px;
-```
-
-### Mix-blend logo
-
-The fixed logo uses `mix-blend-mode: difference` (and `invert(1)` on the mark) so it stays legible over any background it scrolls past. Reference: `.blog-logo`, `.system-logo`.
-
-### Card stacks (FolioEngine)
-
-The portfolio's signature interaction. Cards are absolutely positioned with calculated z-index, randomized rotations (stored per-stack in a `Map`), and negative margins (`-160px`) to create the stacked look. All states are inline styles transitioned at `0.35s ease`, not CSS classes. See `public/components/FolioEngine.js` and `CLAUDE.md` for the expand/collapse flow.
-
-### Content column
-
-Long-form pages (blog, this page) use a centered column — `max-width: 700–760px`, `padding: 48px 24px 80px` — with a fixed `Minimap` for in-page navigation and the fixed logo top-left.

--- a/content/system.mdx
+++ b/content/system.mdx
@@ -68,13 +68,7 @@ The persistent UI that frames every long-form page (blog, this page).
 
 The fixed signature mark, top-left. On index pages it's the `Sig2026.gif`; on article pages it becomes a Lottie (`LogoSpin2026.json`) that spins with scroll direction. It uses `mix-blend-mode: difference` + `invert(1)` so it stays legible over any background it scrolls past. Reference: `app/blog/BlogLogo.tsx`, `app/system/layout.tsx`.
 
-<ComponentPreview
-  source="app/blog/BlogLogo.tsx"
-  code={`<div className="blog-logo">
-  <a href="/"><img src="/assets/Sig2026.gif" width={100} height={100} /></a>
-</div>
-// article pages swap the gif for a scroll-driven Lottie`}
->
+<ComponentPreview>
   <img className="logo-demo" src="/assets/Sig2026.gif" alt="MXMLLN" width={88} height={88} />
 </ComponentPreview>
 
@@ -82,15 +76,7 @@ The fixed signature mark, top-left. On index pages it's the `Sig2026.gif`; on ar
 
 Floating glass pill, centered top. Uppercase Archivo links at low opacity; the active link gets a solid white fill. Reference: `.blog-nav` in `app/blog/blog.css`.
 
-<ComponentPreview
-  source="app/blog/blog.css → .blog-nav"
-  background="glass"
-  code={`<nav className="blog-nav">
-  <a className="active">Work</a>
-  <a>Words</a>
-  <a>About</a>
-</nav>`}
->
+<ComponentPreview background="glass">
   <NavDemo />
 </ComponentPreview>
 
@@ -98,11 +84,6 @@ Floating glass pill, centered top. Uppercase Archivo links at low opacity; the a
 
 Fixed right-rail table-of-contents. Renders a notch per heading (`h2` full-width, `h3` shorter), highlights the section in view via `IntersectionObserver`, and reveals a labeled popover on hover. Reference: `app/blog/Minimap.tsx` — it scans a CSS selector for headings, so it works on any prose page (this page included).
 
-<ComponentPreview
-  source="app/blog/Minimap.tsx"
-  tall
-  code={`<Minimap selector=".system-prose h2[id], .system-prose h3[id]" />
-// notch per heading · active = in view · hover reveals labels`}
->
+<ComponentPreview tall>
   <MinimapDemo />
 </ComponentPreview>


### PR DESCRIPTION
<!-- MAINFRAME_VIDEO_BEGIN -->
> [!TIP]
> **🎬 Watch the walkthrough: [Add design system reference at /system route](https://mainframe.app/v/e6cbeda8ebca951deabfb4cbdf90735c)**
>
> <sup>Generated by [Mainframe](https://mainframe.app). Mainframe automatically generates videos when new pull requests are opened. Configure [here](https://mainframe.app/dashboard/settings/integrations/github).</sup>
<!-- MAINFRAME_VIDEO_END -->

---

Adds a design-system reference for the portfolio: a single source of truth in `content/system.mdx` (color, type, radius, elevation, and motion tokens plus reusable components and patterns) that renders at a new unlisted, `noindex` `/system` route, mirroring the existing blog MDX pipeline. The page (`app/system/`) shows token specimens seeded from `globals.css` alongside live previews of the real `registry/` components, so the docs can't silently drift from the code. It's reachable directly but linked from no nav, intended as a reference for coding agents and for designing new components. Pointers were added to `CLAUDE.md` and `LLMs.txt` so agents discover it before generating UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)