### PR TITLE
Serve raw design-system markdown at /design.md

### DIFF
--- a/app/design.md/route.ts
+++ b/app/design.md/route.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import matter from 'gray-matter';
 
 /**
- * Raw-markdown view of the design system, served at /system.md for agents and
+ * Raw-markdown view of the design system, served at /design.md for agents and
  * LLMs (the /system route only renders HTML). Mirrors how app/system/page.tsx
  * reads the source: same file, frontmatter lifted into a title heading.
  */

--- a/app/system.md/route.ts
+++ b/app/system.md/route.ts
@@ -1,0 +1,26 @@
+import fs from 'fs';
+import path from 'path';
+import matter from 'gray-matter';
+
+/**
+ * Raw-markdown view of the design system, served at /system.md for agents and
+ * LLMs (the /system route only renders HTML). Mirrors how app/system/page.tsx
+ * reads the source: same file, frontmatter lifted into a title heading.
+ */
+export const dynamic = 'force-static';
+
+export function GET() {
+  const filePath = path.join(process.cwd(), 'content', 'system.mdx');
+  const raw = fs.readFileSync(filePath, 'utf-8');
+  const { data, content } = matter(raw);
+
+  const title = (data.title as string | undefined) ?? 'Design System';
+  const body = `# ${title}\n\n${content.trim()}\n`;
+
+  return new Response(body, {
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8',
+      'Cache-Control': 'public, max-age=0, must-revalidate',
+    },
+  });
+}


### PR DESCRIPTION
Adds a route handler at `/design.md` that returns `content/system.mdx` as `text/markdown`, giving agents and LLMs a clean, fetchable source view of the design system. The frontmatter title is lifted into an H1; the `/system` HTML route stays `noindex` and is unaffected. The "system" name is kept for the content file, folder, and HTML route — only the agent-readable URL uses the friendlier `design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)