### PR TITLE
Mousepower: entropy matrix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# local QA screenshot output (frontend-visualqa)
+artifacts/

--- a/app/decks/decks.css
+++ b/app/decks/decks.css
@@ -2531,8 +2531,7 @@
   object-position: center top;
 }
 
-/* Interactive agent-entropy sliders (mousepower/EntropySliders.tsx). Light deck
-   palette, cyan-filled tracks; the verdict box tints by severity. */
+/* Closing 2×2 uncertainty matrix (mousepower/EntropySliders.tsx). */
 .es-stage {
   position: absolute;
   inset: 0;
@@ -2555,14 +2554,9 @@
   background-position: center;
 }
 .es-panel {
-  /* Fill the stage inside its 80px margin. */
   width: 100%;
   height: 100%;
 }
-/* Closing 2×2 matrix (mousepower/EntropySliders.tsx): task-step uncertainty ×
-   acceptance-criteria uncertainty, low vs high. The four quadrant readings sit
-   around a single cyan crossbar — no boxes. Outer grid: y-title | row-heads |
-   plot across columns, x-title | col-heads | plot down rows. */
 .es-matrix {
   width: 100%;
   height: 100%;
@@ -2578,7 +2572,6 @@
   padding-bottom: clamp(28px, 4vh, 48px);
   box-sizing: border-box;
 }
-/* Axis titles in the deck's headline treatment (Archivo SemiBold, Title Case). */
 .es-axis {
   font-family: var(--font-archivo), 'Archivo', sans-serif;
   font-weight: 600;
@@ -2599,9 +2592,7 @@
   writing-mode: vertical-rl;
   transform: rotate(180deg);
 }
-/* The plot: a 2×2 field with a centred black crossbar drawn by pseudo-elements.
-   The axes carry arrowheads (→ increasing uncertainty); low/high are anchored
-   once on the diagonal rather than ticked twice per axis. */
+/* The crossbar is drawn by the ::before (vertical) / ::after (horizontal) rules. */
 .es-plot {
   grid-column: 2;
   grid-row: 2;
@@ -2630,8 +2621,7 @@
   height: 2px;
   transform: translateY(-50%);
 }
-/* Dot anchors mark the low/origin ends (top, left); arrowheads mark the high
-   ends (right, bottom) so each axis points toward more uncertainty. */
+/* Dots mark each axis's low/origin end; arrowheads (below) mark the high end. */
 .es-dot {
   position: absolute;
   width: clamp(9px, 0.85vw, 15px);
@@ -2670,8 +2660,6 @@
   border-right: 8px solid transparent;
   border-top: 13px solid #161616;
 }
-/* Low/high scale labels at each axis end (low at the dot origins, high at the
-   arrowheads) so both axes read unambiguously. */
 .es-tick {
   position: absolute;
   font-family: var(--font-archivo), 'Archivo', sans-serif;
@@ -2703,13 +2691,10 @@
   bottom: 0;
   transform: translate(-50%, calc(100% + 18px));
 }
-/* Diagonal-hatched bands: each takeaway shades off the section it owns. The label
-   sits centred in the band on a solid chip (a cutout of the hatch). Overlapping
-   bands read as crossing hatch, never muddy. */
 .es-hatch {
   position: absolute;
   pointer-events: none;
-  /* Bands reveal one per forward step; hidden until their .es-shown is set. */
+  /* Bands reveal one per forward step; hidden until .es-shown is set (in JS). */
   opacity: 0;
   transition: opacity 0.55s ease;
 }
@@ -2732,8 +2717,6 @@
   padding: clamp(4px, 0.5vw, 10px) clamp(10px, 1vw, 18px);
   border-radius: 6px;
 }
-/* Lowest task-step uncertainty = the left-most quarter, full height. Amber/orange
-   (wasteful, not outright bad) to set it apart from the red danger bands. */
 .es-hatch-script {
   left: 0;
   width: 25%;
@@ -2747,8 +2730,6 @@
     transparent 11px
   );
 }
-/* Highest task-step uncertainty = the right-most quarter, full height. Opposite
-   overlap partner for the bottom band. */
 .es-hatch-ood {
   right: 0;
   width: 25%;
@@ -2762,8 +2743,7 @@
     transparent 11px
   );
 }
-/* Highest acceptance-criteria uncertainty = the bottom fourth, full width.
-   Opposite diagonal (\) so overlaps with the side bands (/) crosshatch. */
+/* Opposite diagonal (\) to the side bands (/) so the overlaps crosshatch. */
 .es-hatch-verif {
   left: 0;
   right: 0;
@@ -2777,8 +2757,6 @@
     transparent 11px
   );
 }
-/* The good zone: central region left unshaded by the red bands. Same diagonal
-   hatch style as the red bands, in cyan. */
 .es-hatch-np {
   left: 25%;
   width: 50%;
@@ -2795,8 +2773,7 @@
 .es-hatch-np .es-hatch-label {
   color: #0e7490;
 }
-/* The two side bands keep their labels outside (no chip), at the top of the
-   shaded area rather than centred. */
+/* Side-band labels sit above the band (no chip) rather than centred. */
 .es-hatch-script .es-hatch-label,
 .es-hatch-ood .es-hatch-label {
   top: auto;

--- a/app/decks/decks.css
+++ b/app/decks/decks.css
@@ -2539,125 +2539,276 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: clamp(28px, 4vw, 80px);
+  padding: 80px;
+  /* The right axis-end "high" tick hangs past the plot; pad extra on the right so
+     it still clears ~80px from the edge (the left is defined by the y-title). */
+  padding-right: clamp(104px, 9vw, 124px);
   box-sizing: border-box;
+  /* Same cyan dot-grid as the horse-gin schematic, for visual continuity. */
+  background-color: #f5f5f5;
+  background-image: radial-gradient(
+    circle,
+    rgba(0, 187, 255, 0.26) 1px,
+    transparent 1.4px
+  );
+  background-size: calc(min(74vw, 940px) * 0.01134) calc(min(74vw, 940px) * 0.01134);
+  background-position: center;
 }
 .es-panel {
-  width: min(92vw, 1100px);
-}
-/* Three dials in a row (mousepower/EntropySliders.tsx), Dieter-Rams dial from
-   exp/003 restyled in the deck's cyan. */
-.es-dials {
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  align-items: flex-start;
-  gap: clamp(20px, 3vw, 64px);
-  flex-wrap: wrap;
-  margin-bottom: clamp(22px, 3.2vh, 48px);
-}
-.es-dial-cell {
-  width: clamp(150px, 16vw, 240px);
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: clamp(10px, 1.2vw, 20px);
-}
-.es-dial-label {
-  text-align: center;
-  font-family: var(--font-archivo), 'Archivo', sans-serif;
-  font-weight: 500;
-  font-size: clamp(13px, 1.15vw, 22px);
-  line-height: 1.3;
-  color: #3B3B3B;
-}
-.es-dial {
-  position: relative;
-  width: clamp(140px, 14vw, 220px);
-  aspect-ratio: 1;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  touch-action: none;
-}
-/* Progress ring: SVG track + fill arcs with round caps. Centre is just the ground
-   (no white disc) — only the knob is white. */
-.es-dial-ring {
-  position: absolute;
-  inset: 0;
-  z-index: 1;
+  /* Fill the stage inside its 80px margin. */
   width: 100%;
   height: 100%;
-  overflow: visible;
 }
-.es-dial-track,
-.es-dial-fill {
-  fill: none;
-  stroke-width: 5;
-  stroke-linecap: round;
+/* Closing 2×2 matrix (mousepower/EntropySliders.tsx): task-step uncertainty ×
+   acceptance-criteria uncertainty, low vs high. The four quadrant readings sit
+   around a single cyan crossbar — no boxes. Outer grid: y-title | row-heads |
+   plot across columns, x-title | col-heads | plot down rows. */
+.es-matrix {
+  width: 100%;
+  height: 100%;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  grid-template-rows: auto 1fr;
+  /* Seats the x-axis "low" tick between the y-title and plot, with clear space. */
+  column-gap: clamp(48px, 5vw, 76px);
+  /* Extra top gap holds the side bands' labels above the plot. */
+  row-gap: clamp(58px, 7vh, 100px);
+  /* Reserve room for the acceptance "high" tick + arrow that hang below the plot
+     so the bottom margin matches the top. */
+  padding-bottom: clamp(28px, 4vh, 48px);
+  box-sizing: border-box;
 }
-.es-dial-track {
-  stroke: #dcdcda;
+/* Axis titles in the deck's headline treatment (Archivo SemiBold, Title Case). */
+.es-axis {
+  font-family: var(--font-archivo), 'Archivo', sans-serif;
+  font-weight: 600;
+  letter-spacing: 0;
+  font-size: clamp(20px, 2.4vw, 44px);
+  line-height: 1.1;
+  color: #161616;
+  text-align: center;
 }
-.es-dial-fill {
-  stroke: #00bbff;
+.es-axis-x {
+  grid-column: 2;
+  grid-row: 1;
 }
-/* The knob: white disc with a soft drop shadow + an accent dot at its top. */
-.es-dial-knob {
+.es-axis-y {
+  grid-column: 1;
+  grid-row: 2;
+  align-self: center;
+  writing-mode: vertical-rl;
+  transform: rotate(180deg);
+}
+/* The plot: a 2×2 field with a centred black crossbar drawn by pseudo-elements.
+   The axes carry arrowheads (→ increasing uncertainty); low/high are anchored
+   once on the diagonal rather than ticked twice per axis. */
+.es-plot {
+  grid-column: 2;
+  grid-row: 2;
   position: relative;
-  z-index: 2;
-  width: 62%;
-  aspect-ratio: 1;
-  border-radius: 50%;
-  background: #fff;
-  box-shadow: inset -1px -1px 5px rgba(0, 0, 0, 0.05),
-    2px 2px 12px rgba(0, 0, 0, 0.1), 4px 4px 24px rgba(0, 0, 0, 0.12);
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: 1fr 1fr;
 }
-.es-dial-knob::before {
+.es-plot::before,
+.es-plot::after {
   content: '';
   position: absolute;
-  top: 7%;
+  background: #161616;
+}
+.es-plot::before {
+  top: 0;
+  bottom: 0;
   left: 50%;
-  width: 7%;
+  width: 2px;
+  transform: translateX(-50%);
+}
+.es-plot::after {
+  left: 0;
+  right: 0;
+  top: 50%;
+  height: 2px;
+  transform: translateY(-50%);
+}
+/* Dot anchors mark the low/origin ends (top, left); arrowheads mark the high
+   ends (right, bottom) so each axis points toward more uncertainty. */
+.es-dot {
+  position: absolute;
+  width: clamp(9px, 0.85vw, 15px);
   aspect-ratio: 1;
-  transform: translate(-50%, 0);
   border-radius: 50%;
-  background: #00bbff;
-  box-shadow: 1px 1px 4px rgba(0, 187, 255, 0.35);
+  background: #161616;
 }
-.es-verdict {
-  margin-top: clamp(8px, 1vh, 16px);
-  padding: clamp(14px, 1.4vw, 26px) clamp(16px, 1.6vw, 30px);
-  border: 1px solid var(--border, #dcdcda);
-  border-radius: clamp(10px, 0.8vw, 16px);
-  min-height: 3.6em;
-  display: flex;
-  align-items: center;
-  transition: background 0.25s ease, border-color 0.25s ease;
+.es-dot-top {
+  top: 0;
+  left: 50%;
+  transform: translate(-50%, -50%);
 }
-.es-verdict-text {
-  margin: 0;
+.es-dot-left {
+  left: 0;
+  top: 50%;
+  transform: translate(-50%, -50%);
+}
+.es-arrow {
+  position: absolute;
+  width: 0;
+  height: 0;
+}
+.es-arrow-x {
+  top: 50%;
+  right: 0;
+  transform: translate(60%, -50%);
+  border-top: 8px solid transparent;
+  border-bottom: 8px solid transparent;
+  border-left: 13px solid #161616;
+}
+.es-arrow-y {
+  left: 50%;
+  bottom: 0;
+  transform: translate(-50%, 60%);
+  border-left: 8px solid transparent;
+  border-right: 8px solid transparent;
+  border-top: 13px solid #161616;
+}
+/* Low/high scale labels at each axis end (low at the dot origins, high at the
+   arrowheads) so both axes read unambiguously. */
+.es-tick {
+  position: absolute;
   font-family: var(--font-archivo), 'Archivo', sans-serif;
-  font-size: clamp(15px, 1.5vw, 28px);
-  line-height: 1.5;
-  color: #3B3B3B;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: clamp(11px, 1vw, 18px);
+  color: #6b6b6b;
+  white-space: nowrap;
 }
-.es-success {
-  background: #e7f5ec;
-  border-color: #1d9e75;
+/* x-axis (Task Steps) low/high read vertically — rotated 90° ccw. */
+.es-tick-xlow {
+  top: 50%;
+  left: 0;
+  transform: translate(calc(-100% - 14px), -50%) rotate(-90deg);
 }
-.es-danger {
-  background: #fce9e9;
-  border-color: #a32d2d;
+.es-tick-xhigh {
+  top: 50%;
+  right: 0;
+  transform: translate(calc(100% + 18px), -50%) rotate(-90deg);
 }
-.es-warn {
-  background: #fbf3e2;
-  border-color: #ba7517;
+.es-tick-ylow {
+  left: 50%;
+  top: 0;
+  transform: translate(-50%, calc(-100% - 14px));
 }
-.es-neutral {
-  background: #fff;
-  border-color: #dcdcda;
+.es-tick-yhigh {
+  left: 50%;
+  bottom: 0;
+  transform: translate(-50%, calc(100% + 18px));
+}
+/* Diagonal-hatched bands: each takeaway shades off the section it owns. The label
+   sits centred in the band on a solid chip (a cutout of the hatch). Overlapping
+   bands read as crossing hatch, never muddy. */
+.es-hatch {
+  position: absolute;
+  pointer-events: none;
+  /* Bands reveal one per forward step; hidden until their .es-shown is set. */
+  opacity: 0;
+  transition: opacity 0.55s ease;
+}
+.es-hatch.es-shown {
+  opacity: 1;
+}
+.es-hatch-label {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-family: var(--font-archivo), 'Archivo', sans-serif;
+  font-weight: 700;
+  font-size: clamp(14px, 1.3vw, 24px);
+  line-height: 1.3;
+  text-align: center;
+  white-space: nowrap;
+  color: #c0392b;
+  background: #f5f5f5;
+  padding: clamp(4px, 0.5vw, 10px) clamp(10px, 1vw, 18px);
+  border-radius: 6px;
+}
+/* Lowest task-step uncertainty = the left-most quarter, full height. Amber/orange
+   (wasteful, not outright bad) to set it apart from the red danger bands. */
+.es-hatch-script {
+  left: 0;
+  width: 25%;
+  top: 0;
+  bottom: 0;
+  background: repeating-linear-gradient(
+    45deg,
+    rgba(232, 152, 18, 0.62) 0,
+    rgba(232, 152, 18, 0.62) 2px,
+    transparent 2px,
+    transparent 11px
+  );
+}
+/* Highest task-step uncertainty = the right-most quarter, full height. Opposite
+   overlap partner for the bottom band. */
+.es-hatch-ood {
+  right: 0;
+  width: 25%;
+  top: 0;
+  bottom: 0;
+  background: repeating-linear-gradient(
+    45deg,
+    rgba(192, 57, 43, 0.55) 0,
+    rgba(192, 57, 43, 0.55) 2px,
+    transparent 2px,
+    transparent 11px
+  );
+}
+/* Highest acceptance-criteria uncertainty = the bottom fourth, full width.
+   Opposite diagonal (\) so overlaps with the side bands (/) crosshatch. */
+.es-hatch-verif {
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 25%;
+  background: repeating-linear-gradient(
+    -45deg,
+    rgba(192, 57, 43, 0.55) 0,
+    rgba(192, 57, 43, 0.55) 2px,
+    transparent 2px,
+    transparent 11px
+  );
+}
+/* The good zone: central region left unshaded by the red bands. Same diagonal
+   hatch style as the red bands, in cyan. */
+.es-hatch-np {
+  left: 25%;
+  width: 50%;
+  top: 0;
+  height: 75%;
+  background: repeating-linear-gradient(
+    -45deg,
+    rgba(0, 187, 255, 0.55) 0,
+    rgba(0, 187, 255, 0.55) 2px,
+    transparent 2px,
+    transparent 11px
+  );
+}
+.es-hatch-np .es-hatch-label {
+  color: #0e7490;
+}
+/* The two side bands keep their labels outside (no chip), at the top of the
+   shaded area rather than centred. */
+.es-hatch-script .es-hatch-label,
+.es-hatch-ood .es-hatch-label {
+  top: auto;
+  bottom: 100%;
+  transform: translate(-50%, 0);
+  margin-bottom: clamp(10px, 1.2vh, 18px);
+  background: none;
+  padding: 0;
+  border-radius: 0;
+}
+.es-hatch-script .es-hatch-label {
+  color: #a3690c;
 }
 .dl-emoji {
   font-size: 46px;

--- a/app/decks/mousepower/EntropySliders.tsx
+++ b/app/decks/mousepower/EntropySliders.tsx
@@ -1,10 +1,8 @@
 'use client';
 
-// 2×2 takeaway map. Axes: Uncertainty in Acceptance Criteria (x, low→high
-// left→right) × Uncertainty in Task Steps (y, low→high top→bottom). Each takeaway
-// owns a diagonal-hatched band; overlapping bands crosshatch rather than muddy.
-// The bands reveal one per forward step (bare chart → script → OOD → verification
-// → NP), using the same capture-phase key interception as the other build slides.
+// The takeaway bands reveal one per forward step (bare chart → script → OOD →
+// verification → NP). Forward/back keys are intercepted in the capture phase so
+// the deck only changes slides at the first/last step (as in the other builds).
 import { useEffect, useState } from 'react';
 import { useDeck, useSlideIndex } from '../Deck';
 
@@ -18,7 +16,6 @@ export function EntropySliders() {
   const active = activeIndex === index;
   const [step, setStep] = useState(0);
 
-  // Reset to the bare chart whenever the slide (re)enters.
   useEffect(() => {
     if (active) setStep(0);
   }, [active]);
@@ -59,26 +56,20 @@ export function EntropySliders() {
             <span className="es-tick es-tick-ylow">low</span>
             <span className="es-tick es-tick-yhigh">high</span>
 
-            {/* Lowest task-step uncertainty = the left-most quarter, full height. */}
             <div className={`es-hatch es-hatch-script${shown(1)}`}>
               <span className="es-hatch-label">Write a script, save tokens</span>
             </div>
-            {/* Highest task-step uncertainty = the right-most quarter. */}
             <div className={`es-hatch es-hatch-ood${shown(2)}`}>
               <span className="es-hatch-label">
                 Data risk of OOD in pretraining /<br />
                 sparse rewards for RL
               </span>
             </div>
-            {/* Highest acceptance-criteria uncertainty = the bottom fourth, full
-                width. Opposite diagonal so its overlaps with the side bands read
-                as crosshatch. */}
             <div className={`es-hatch es-hatch-verif${shown(3)}`}>
               <span className="es-hatch-label">
                 Verification is indistinguishable from execution
               </span>
             </div>
-            {/* The good zone: the central region left unshaded by the red bands. */}
             <div className={`es-hatch es-hatch-np${shown(4)}`}>
               <span className="es-hatch-label">
                 {'Verification ~< execution'}

--- a/app/decks/mousepower/EntropySliders.tsx
+++ b/app/decks/mousepower/EntropySliders.tsx
@@ -1,185 +1,92 @@
 'use client';
 
-// Interactive closer: the agent-entropy model as three dials feeding a live
-// verdict. Dials follow the Dieter-Rams dial from exp/003 (−140°→+140° sweep,
-// conic progress ring, accent dot) restyled in the deck's cyan. Logic mirrors the
-// brainstorm prototype: tiered thresholds (low 0–33 / mid 34–66 / high 67–100),
-// an override precedence, then a composed reading from the low/high fragments.
-import { useRef, useState } from 'react';
+// 2×2 takeaway map. Axes: Uncertainty in Acceptance Criteria (x, low→high
+// left→right) × Uncertainty in Task Steps (y, low→high top→bottom). Each takeaway
+// owns a diagonal-hatched band; overlapping bands crosshatch rather than muddy.
+// The bands reveal one per forward step (bare chart → script → OOD → verification
+// → NP), using the same capture-phase key interception as the other build slides.
+import { useEffect, useState } from 'react';
+import { useDeck, useSlideIndex } from '../Deck';
 
-const tier = (v: number) => (v <= 33 ? 0 : v <= 66 ? 1 : 2);
-
-// Only LOW and HIGH fragments carry text; MID (null) is omitted from composition.
-const T = [
-  'the task reduces to a static, deterministic script',
-  null,
-  'the task’s data is less compressible, therefore less predictable',
-];
-const A = [
-  'the agent is likely to generalize to new instances of unseen data for this task',
-  null,
-  'high probability that the data is OOD and/or rewards are too sparse for RL',
-];
-const V = [
-  'verification has the NP-style asymmetry — far cheaper to check than to solve, and its validity is confirmable',
-  null,
-  'verification collapses into redoing the work, so its validity rests on faith',
-];
-
-const cap1 = (s: string) => s.charAt(0).toUpperCase() + s.slice(1);
-
-type Sev = 'success' | 'danger' | 'warn' | 'neutral';
-
-function compute(cap: number, task: number, verif: number) {
-  const ta = tier(cap); // agent (epistemic)
-  const tt = tier(task); // task (aleatoric)
-  const tv = tier(verif); // verification
-  let text = '';
-  let sev: Sev;
-
-  // Override precedence: verification-collapse > static-script > agent-uncertainty > composition.
-  if (tv === 2) {
-    text =
-      'Verification collapses into redoing the work — the cost to check equals the cost to do the task, so the agent earns nothing no matter how the task or the agent is shaped. The worst case.';
-    sev = 'danger';
-  } else if (tt === 0) {
-    text =
-      'The task reduces to a static, deterministic script — its outcome is fixed, so an agent adds nothing here.';
-    sev = 'warn';
-  } else if (ta === 2) {
-    text = 'High probability that the data is OOD and/or rewards are too sparse for RL.';
-    sev = 'danger';
-  } else {
-    const parts = [T[tt], A[ta], V[tv]].filter(Boolean) as string[];
-    text = parts.length ? cap1(parts.join('; ')) + '.' : '';
-    if (tt === 1 && ta === 0 && tv === 0) sev = 'success';
-    else if (tt === 2 && ta === 0 && tv === 0) sev = 'success';
-    else sev = 'neutral';
-  }
-
-  return { text, sev };
-}
-
-// Dial sweep: value 0 → −140°, value 100 → +140° (280° total, 80° gap at bottom).
-const A0 = -140;
-const SPAN = 280;
-
-// Ring arc geometry (viewBox 100). Clock angle: 0 = top, clockwise.
-const RR = 44;
-const ptOn = (deg: number) => {
-  const a = (deg * Math.PI) / 180;
-  return [50 + RR * Math.sin(a), 50 - RR * Math.cos(a)] as const;
-};
-const arcPath = (t1: number, t2: number) => {
-  const [x1, y1] = ptOn(t1);
-  const [x2, y2] = ptOn(t2);
-  const large = Math.abs(t2 - t1) > 180 ? 1 : 0;
-  return `M ${x1} ${y1} A ${RR} ${RR} 0 ${large} 1 ${x2} ${y2}`;
-};
-
-function Dial({
-  label,
-  tag,
-  value,
-  onChange,
-}: {
-  label: string;
-  tag?: string;
-  value: number;
-  onChange: (v: number) => void;
-}) {
-  const ref = useRef<HTMLDivElement>(null);
-  const dragging = useRef(false);
-
-  const angle = A0 + (value / 100) * SPAN;
-
-  // Pointer angle → value, measured from the dial centre (0° = top, clockwise).
-  const setFrom = (clientX: number, clientY: number) => {
-    const el = ref.current;
-    if (!el) return;
-    const r = el.getBoundingClientRect();
-    let a =
-      (Math.atan2(clientY - (r.top + r.height / 2), clientX - (r.left + r.width / 2)) * 180) /
-        Math.PI +
-      90;
-    if (a > 180) a -= 360;
-    if (a < -180) a += 360;
-    a = Math.max(A0, Math.min(-A0, a));
-    onChange(Math.round(((a - A0) / SPAN) * 100));
-  };
-
-  return (
-    <div className="es-dial-cell">
-      <div
-        ref={ref}
-        className="es-dial"
-        role="slider"
-        aria-label={label}
-        aria-valuemin={0}
-        aria-valuemax={100}
-        aria-valuenow={value}
-        onPointerDown={(e) => {
-          e.currentTarget.setPointerCapture(e.pointerId);
-          dragging.current = true;
-          setFrom(e.clientX, e.clientY);
-        }}
-        onPointerMove={(e) => {
-          if (dragging.current) setFrom(e.clientX, e.clientY);
-        }}
-        onPointerUp={(e) => {
-          e.currentTarget.releasePointerCapture(e.pointerId);
-          dragging.current = false;
-        }}
-        onPointerCancel={() => {
-          dragging.current = false;
-        }}
-      >
-        <svg className="es-dial-ring" viewBox="0 0 100 100" aria-hidden>
-          <path className="es-dial-track" d={arcPath(A0, -A0)} />
-          <path className="es-dial-fill" d={arcPath(A0, angle)} />
-        </svg>
-        <div className="es-dial-knob" style={{ transform: `rotate(${angle}deg)` }} />
-      </div>
-      <div className="es-dial-label">
-        {label}
-        {tag && ` (${tag})`}
-      </div>
-    </div>
-  );
-}
+const STEPS = 5; // 0 = bare chart; 1..4 reveal each band in turn
+const FWD = new Set(['ArrowRight', 'ArrowDown', ' ']);
+const BACK = new Set(['ArrowLeft', 'ArrowUp', 'Backspace']);
 
 export function EntropySliders() {
-  // value order mirrors the prototype ids: cap = agent epistemic, task, verif.
-  const [cap, setCap] = useState(50);
-  const [task, setTask] = useState(50);
-  const [verif, setVerif] = useState(50);
-  const { text, sev } = compute(cap, task, verif);
+  const { activeIndex } = useDeck();
+  const index = useSlideIndex();
+  const active = activeIndex === index;
+  const [step, setStep] = useState(0);
+
+  // Reset to the bare chart whenever the slide (re)enters.
+  useEffect(() => {
+    if (active) setStep(0);
+  }, [active]);
+
+  useEffect(() => {
+    if (!active) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (FWD.has(e.key) && step < STEPS - 1) {
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        setStep((s) => Math.min(s + 1, STEPS - 1));
+      } else if (BACK.has(e.key) && step > 0) {
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        setStep((s) => Math.max(s - 1, 0));
+      }
+      // At a boundary: let the event reach the Deck to change slides.
+    };
+    window.addEventListener('keydown', onKey, { capture: true });
+    return () => window.removeEventListener('keydown', onKey, { capture: true });
+  }, [active, step]);
+
+  const shown = (n: number) => (step >= n ? ' es-shown' : '');
 
   return (
     <div className="es-stage rack-in">
       <div className="es-panel">
-        <div className="es-dials">
-          <Dial
-            label="Agent’s uncertainty about the task"
-            tag="epistemic"
-            value={cap}
-            onChange={setCap}
-          />
-          <Dial
-            label="Inherent uncertainty in the task"
-            tag="aleatoric"
-            value={task}
-            onChange={setTask}
-          />
-          <Dial
-            label="Uncertainty in the verification process"
-            value={verif}
-            onChange={setVerif}
-          />
-        </div>
+        <div className="es-matrix">
+          <span className="es-axis es-axis-x">Uncertainty in Acceptance Criteria</span>
+          <span className="es-axis es-axis-y">Uncertainty in Task Steps</span>
+          <div className="es-plot">
+            <span className="es-dot es-dot-top" aria-hidden />
+            <span className="es-dot es-dot-left" aria-hidden />
+            <span className="es-arrow es-arrow-x" aria-hidden />
+            <span className="es-arrow es-arrow-y" aria-hidden />
+            <span className="es-tick es-tick-xlow">low</span>
+            <span className="es-tick es-tick-xhigh">high</span>
+            <span className="es-tick es-tick-ylow">low</span>
+            <span className="es-tick es-tick-yhigh">high</span>
 
-        <div className={`es-verdict es-${sev}`}>
-          <p className="es-verdict-text">{text || '—'}</p>
+            {/* Lowest task-step uncertainty = the left-most quarter, full height. */}
+            <div className={`es-hatch es-hatch-script${shown(1)}`}>
+              <span className="es-hatch-label">Write a script, save tokens</span>
+            </div>
+            {/* Highest task-step uncertainty = the right-most quarter. */}
+            <div className={`es-hatch es-hatch-ood${shown(2)}`}>
+              <span className="es-hatch-label">
+                Data risk of OOD in pretraining /<br />
+                sparse rewards for RL
+              </span>
+            </div>
+            {/* Highest acceptance-criteria uncertainty = the bottom fourth, full
+                width. Opposite diagonal so its overlaps with the side bands read
+                as crosshatch. */}
+            <div className={`es-hatch es-hatch-verif${shown(3)}`}>
+              <span className="es-hatch-label">
+                Verification is indistinguishable from execution
+              </span>
+            </div>
+            {/* The good zone: the central region left unshaded by the red bands. */}
+            <div className={`es-hatch es-hatch-np${shown(4)}`}>
+              <span className="es-hatch-label">
+                {'Verification ~< execution'}
+                <br />
+                NP w/ adversarial agents ;)
+              </span>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/app/decks/mousepower/page.tsx
+++ b/app/decks/mousepower/page.tsx
@@ -114,7 +114,7 @@ export default function MousepowerDeck() {
         <EntropyPaper />
       </div>
 
-      {/* Interactive: the agent-entropy model as three sliders + live verdict. */}
+      {/* Closing 2×2 uncertainty matrix with stepped band reveals. */}
       <div className="slide" style={{ background: '#f5f5f5', color: '#3B3B3B' }}>
         <EntropySliders />
       </div>


### PR DESCRIPTION
<!-- MAINFRAME_VIDEO_BEGIN -->
> [!TIP]
> **🎬 Watch the walkthrough: [Replace entropy dials with a stepped 2×2 uncertainty matrix in Mousepower](https://mainframe.app/v/69cbd15ad6c870b37831f54ab18f12d7)**
>
> <sup>Generated by [Mainframe](https://mainframe.app). Mainframe automatically generates videos when new pull requests are opened. Configure [here](https://mainframe.app/dashboard/settings/integrations/github).</sup>
<!-- MAINFRAME_VIDEO_END -->

---

Reworks the closing EntropySliders slide from three interactive dials + a live verdict into a static 2×2 map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)