### PR TITLE
Reader: add showDirectoryPicker link to reading list

### DIFF
--- a/public/reader/reading-list.json
+++ b/public/reader/reading-list.json
@@ -759,6 +759,14 @@
       "createdAt": "2026-07-10T12:00:02.000Z",
       "metadata": {},
       "read": false
+    },
+    {
+      "id": "1781352000012",
+      "url": "https://steveharrison.dev/showdirectorypicker-opens-up-a-whole-new-world/",
+      "title": "window.showDirectoryPicker opens up a whole new world",
+      "createdAt": "2026-07-13T12:00:00.000Z",
+      "metadata": {},
+      "read": false
     }
   ]
 }


### PR DESCRIPTION
Adds one link to the reader's reading list: Steve Harrison's "window.showDirectoryPicker opens up a whole new world". The entry follows the existing schema (id, url, title, createdAt, empty metadata, unread). The screenshot will be auto-captured by the reader server's capture-missing flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)