### PR TITLE
System: add copyable anchor links to section headings

### DIFF
--- a/app/system/components/AnchorHeading.tsx
+++ b/app/system/components/AnchorHeading.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import React, { useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^\w\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .trim();
+}
+
+function CopyIcon() {
+  return (
+    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path d="M10 13a5 5 0 0 0 7.07 0l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+      <path d="M14 11a5 5 0 0 0-7.07 0l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+function CheckIcon() {
+  return (
+    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path d="M20 6L9 17l-5-5" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+/**
+ * Section headings double as copyable anchors so a component can be handed to
+ * an agent or teammate by URL reference.
+ */
+export function AnchorHeading({
+  as: Tag,
+  children,
+}: {
+  as: 'h2' | 'h3';
+  children: React.ReactNode;
+}) {
+  const [copied, setCopied] = useState(false);
+  const text = typeof children === 'string' ? children : String(children);
+  const id = slugify(text);
+
+  const copy = async () => {
+    const url = `${window.location.origin}${window.location.pathname}#${id}`;
+    try {
+      await navigator.clipboard.writeText(url);
+    } catch {
+      // clipboard blocked — still update the hash so the URL is shareable
+    }
+    history.replaceState(null, '', `#${id}`);
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1400);
+  };
+
+  return (
+    <Tag id={id} className="anchor-heading">
+      {children}
+      <button
+        type="button"
+        className="anchor-heading-link"
+        onClick={copy}
+        aria-label={`Copy link to “${text}”`}
+        title="Copy link to this section"
+      >
+        <AnimatePresence mode="popLayout" initial={false}>
+          <motion.span
+            key={copied ? 'check' : 'copy'}
+            initial={{ opacity: 0, scale: 0.25, filter: 'blur(4px)' }}
+            animate={{ opacity: 1, scale: 1, filter: 'blur(0px)' }}
+            exit={{ opacity: 0, scale: 0.25, filter: 'blur(4px)' }}
+            transition={{ type: 'spring', duration: 0.3, bounce: 0 }}
+            className="anchor-heading-icon"
+          >
+            {copied ? <CheckIcon /> : <CopyIcon />}
+          </motion.span>
+        </AnimatePresence>
+      </button>
+    </Tag>
+  );
+}

--- a/app/system/page.tsx
+++ b/app/system/page.tsx
@@ -12,6 +12,7 @@ import {
   Type,
 } from './components/TokenSwatch';
 import { ComponentPreview } from './components/ComponentPreview';
+import { AnchorHeading } from './components/AnchorHeading';
 import { LogoDemo, NavDemo, MenuDemo } from './components/ChromeDemos';
 import { ButtonDemo, InputDemo } from './components/FormDemos';
 import { CardDemo } from './components/CardDemos';
@@ -25,27 +26,11 @@ export const metadata: Metadata = {
   robots: { index: false, follow: false },
 };
 
-function slugify(text: string): string {
-  return text
-    .toLowerCase()
-    .replace(/[^\w\s-]/g, '')
-    .replace(/\s+/g, '-')
-    .replace(/-+/g, '-')
-    .trim();
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function HeadingWithId(Tag: 'h2' | 'h3') {
-  return function Heading(props: any) {
-    const text =
-      typeof props.children === 'string' ? props.children : String(props.children);
-    return <Tag id={slugify(text)} {...props} />;
-  };
-}
-
 const mdxComponents: MDXComponents = {
-  h2: HeadingWithId('h2'),
-  h3: HeadingWithId('h3'),
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  h2: (props: any) => <AnchorHeading as="h2">{props.children}</AnchorHeading>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  h3: (props: any) => <AnchorHeading as="h3">{props.children}</AnchorHeading>,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   a: ({ href, children, ...rest }: any) => {
     const isExternal = (href || '').startsWith('http') || (href || '').startsWith('//');

--- a/app/system/system.css
+++ b/app/system/system.css
@@ -89,6 +89,51 @@
   margin: 40px 0 12px;
   scroll-margin-top: 32px;
 }
+
+/* Copyable section anchors */
+.anchor-heading {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.anchor-heading-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: none;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border: none;
+  border-radius: 50%;
+  background: #f2f2f2;
+  color: #8a8a8a;
+  cursor: pointer;
+  opacity: 0;
+  transform: scale(0.85);
+  transition: opacity 0.2s ease, transform 0.2s ease, color 0.2s ease,
+    background 0.2s ease;
+}
+.anchor-heading:hover .anchor-heading-link,
+.anchor-heading-link:focus-visible {
+  opacity: 1;
+  transform: scale(1);
+}
+.anchor-heading-link:hover {
+  color: #1a1a1a;
+  background: #e9e9e9;
+}
+.anchor-heading-link:active {
+  transform: scale(0.92);
+}
+.anchor-heading-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.anchor-heading-icon svg {
+  display: block;
+}
 .system-prose p {
   margin: 0 0 24px;
 }


### PR DESCRIPTION
Lets a component on the `/system` design-system page be referenced by URL when handed to an agent or teammate: each heading gains a copy-link button (styled after jakub.kr, with a framer-motion icon-morph on copy) that copies the section's absolute anchor URL.