### PR TITLE
Remove stray .gitignore.rtf file

### DIFF
--- a/.gitignore.rtf
+++ b/.gitignore.rtf
@@ -1,8 +1,0 @@
-{\rtf1\ansi\ansicpg1252\cocoartf2759
-\cocoatextscaling0\cocoaplatform0{\fonttbl\f0\fswiss\fcharset0 Helvetica;}
-{\colortbl;\red255\green255\blue255;}
-{\*\expandedcolortbl;;}
-\margl1440\margr1440\vieww11520\viewh8400\viewkind0
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
-
-\f0\fs24 \cf0 .env}


### PR DESCRIPTION
A `.gitignore` was accidentally saved as RTF (TextEdit rich-text mode), so it was named `.gitignore.rtf` — invisible to Git and full of formatting markup. The real `.gitignore` already covers everything it intended (`.env`, etc.), so this just removes the dead file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)