### PR TITLE
Sebastian: replace nav with a top segmented bar + mobile menu

### DIFF
--- a/app/sebastian/Gallery.tsx
+++ b/app/sebastian/Gallery.tsx
@@ -24,9 +24,11 @@ export default function Gallery({ photos }: { photos: Photo[] }) {
     };
     window.addEventListener("keydown", onKey);
     document.body.style.overflow = "hidden";
+    window.dispatchEvent(new CustomEvent("seb-lightbox", { detail: true }));
     return () => {
       window.removeEventListener("keydown", onKey);
       document.body.style.overflow = "";
+      window.dispatchEvent(new CustomEvent("seb-lightbox", { detail: false }));
     };
   }, [openIndex, close, step]);
 
@@ -59,7 +61,7 @@ export default function Gallery({ photos }: { photos: Photo[] }) {
 
       {openIndex !== null && (
         <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-white/95 p-6"
+          className="fixed inset-0 z-[1000] flex items-center justify-center bg-white/95 p-6"
           onClick={close}
         >
           <img

--- a/app/sebastian/Gallery.tsx
+++ b/app/sebastian/Gallery.tsx
@@ -24,6 +24,7 @@ export default function Gallery({ photos }: { photos: Photo[] }) {
     };
     window.addEventListener("keydown", onKey);
     document.body.style.overflow = "hidden";
+    // Consumed by SebNav so the top nav hides behind the overlay.
     window.dispatchEvent(new CustomEvent("seb-lightbox", { detail: true }));
     return () => {
       window.removeEventListener("keydown", onKey);

--- a/app/sebastian/SebNav.tsx
+++ b/app/sebastian/SebNav.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useEffect, useState } from "react";
+
+const items = [
+  { href: "/sebastian", label: "Albums" },
+  { href: "/sebastian/about", label: "About" },
+  { href: "/sebastian/clients", label: "Clients" },
+  { href: "/sebastian/contact", label: "Contact" },
+];
+
+function isActive(pathname: string, href: string): boolean {
+  if (href === "/sebastian") {
+    // Albums is the default: active on the home grid and any album/section page,
+    // i.e. anything that isn't About / Clients / Contact.
+    return !items
+      .filter((i) => i.href !== "/sebastian")
+      .some((i) => pathname.startsWith(i.href));
+  }
+  return pathname === href || pathname.startsWith(`${href}/`);
+}
+
+const glass = {
+  backdropFilter: "blur(80px)",
+  WebkitBackdropFilter: "blur(80px)",
+  backgroundColor: "rgba(240, 240, 240, 0.65)",
+  boxShadow: "0px 3px 30px 0px rgba(0, 0, 0, 0.15)",
+  border: "solid 2px rgba(0, 0, 0, 0.1)",
+} as const;
+
+const itemFont = { fontFamily: "var(--font-cormorant), serif" } as const;
+const itemBase =
+  "text-[18px] font-medium tracking-wide text-black transition-opacity";
+
+export default function SebNav() {
+  const pathname = usePathname() ?? "/sebastian";
+  const [open, setOpen] = useState(false);
+  const [hidden, setHidden] = useState(false);
+
+  const activeLabel =
+    items.find((i) => isActive(pathname, i.href))?.label ?? "Menu";
+
+  // Close the mobile menu on navigation and on Escape.
+  useEffect(() => setOpen(false), [pathname]);
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open]);
+
+  // Hide the nav entirely while a gallery lightbox is open.
+  useEffect(() => {
+    const onLightbox = (e: Event) =>
+      setHidden((e as CustomEvent<boolean>).detail === true);
+    window.addEventListener("seb-lightbox", onLightbox);
+    return () => window.removeEventListener("seb-lightbox", onLightbox);
+  }, []);
+
+  if (hidden) return null;
+
+  return (
+    <nav className="pointer-events-none fixed inset-x-0 top-5 z-[900] flex justify-center px-4">
+      {/* Desktop: segmented controller */}
+      <div
+        className="pointer-events-auto hidden items-center gap-1.5 rounded-[40px] p-1.5 sm:flex"
+        style={glass}
+      >
+        {items.map((item) => {
+          const active = isActive(pathname, item.href);
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              aria-current={active ? "page" : undefined}
+              className={`rounded-[40px] px-5 py-2 leading-none ${itemBase} ${
+                active ? "bg-white" : "hover:opacity-50"
+              }`}
+              style={itemFont}
+            >
+              {item.label}
+            </Link>
+          );
+        })}
+      </div>
+
+      {/* Mobile: hamburger menu */}
+      <div className="pointer-events-auto relative flex flex-col items-center sm:hidden">
+        <button
+          type="button"
+          aria-label={open ? "Close menu" : "Open menu"}
+          aria-expanded={open}
+          onClick={() => setOpen((v) => !v)}
+          className="flex items-center gap-3 rounded-[40px] py-3 pl-5 pr-4"
+          style={glass}
+        >
+          <span className={`leading-none ${itemBase}`} style={itemFont}>
+            {activeLabel}
+          </span>
+          <span className="relative flex h-4 w-5 flex-col justify-between">
+            <span
+              className={`h-[2px] w-full rounded-full bg-black transition-transform duration-300 ${
+                open ? "translate-y-[7px] rotate-45" : ""
+              }`}
+            />
+            <span
+              className={`h-[2px] w-full rounded-full bg-black transition-opacity duration-300 ${
+                open ? "opacity-0" : ""
+              }`}
+            />
+            <span
+              className={`h-[2px] w-full rounded-full bg-black transition-transform duration-300 ${
+                open ? "-translate-y-[7px] -rotate-45" : ""
+              }`}
+            />
+          </span>
+        </button>
+
+        {open && (
+          <div
+            className="mt-2 flex w-44 flex-col gap-1 rounded-[24px] p-2"
+            style={glass}
+          >
+            {items.map((item) => {
+              const active = isActive(pathname, item.href);
+              return (
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  aria-current={active ? "page" : undefined}
+                  className={`rounded-[16px] px-5 py-3 text-center ${itemBase} ${
+                    active ? "bg-white" : "hover:opacity-50"
+                  }`}
+                  style={itemFont}
+                >
+                  {item.label}
+                </Link>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </nav>
+  );
+}

--- a/app/sebastian/SebNav.tsx
+++ b/app/sebastian/SebNav.tsx
@@ -42,7 +42,6 @@ export default function SebNav() {
   const activeLabel =
     items.find((i) => isActive(pathname, i.href))?.label ?? "Menu";
 
-  // Close the mobile menu on navigation and on Escape.
   useEffect(() => setOpen(false), [pathname]);
   useEffect(() => {
     if (!open) return;
@@ -53,7 +52,7 @@ export default function SebNav() {
     return () => window.removeEventListener("keydown", onKey);
   }, [open]);
 
-  // Hide the nav entirely while a gallery lightbox is open.
+  // seb-lightbox is dispatched by Gallery so the nav can clear the overlay.
   useEffect(() => {
     const onLightbox = (e: Event) =>
       setHidden((e as CustomEvent<boolean>).detail === true);

--- a/app/sebastian/clients/page.tsx
+++ b/app/sebastian/clients/page.tsx
@@ -1,4 +1,4 @@
-import { clients, wixImage } from "../data";
+import { clients, wixLogo } from "../data";
 
 export default function ClientsPage() {
   return (
@@ -16,7 +16,7 @@ export default function ClientsPage() {
             className="flex aspect-square items-center justify-center p-4"
           >
             <img
-              src={wixImage(client.uri, 400)}
+              src={wixLogo(client.uri, 400)}
               alt={client.title}
               title={client.title}
               loading="lazy"

--- a/app/sebastian/contact/page.tsx
+++ b/app/sebastian/contact/page.tsx
@@ -11,8 +11,15 @@ export default function ContactPage() {
       </h2>
       <p className="text-[15px] leading-relaxed text-neutral-700">
         {contact.intro}
+        <a
+          href={`mailto:${contact.email}`}
+          className="underline underline-offset-4 hover:text-black"
+        >
+          {contact.email}
+        </a>
+        .
       </p>
-      <p className="mt-4 text-[15px] leading-relaxed text-neutral-700">
+      <p className="mt-10 text-[15px] leading-relaxed text-neutral-700">
         {contact.redux.prefix}
         <a
           href={contact.redux.url}
@@ -24,17 +31,6 @@ export default function ContactPage() {
         </a>
         .
       </p>
-      <div className="mt-10 space-y-2 text-[15px]">
-        <p>
-          <a
-            href={`mailto:${contact.email}`}
-            className="underline underline-offset-4 hover:text-black"
-          >
-            {contact.email}
-          </a>
-        </p>
-        <p className="text-neutral-700">{contact.phone}</p>
-      </div>
     </div>
   );
 }

--- a/app/sebastian/data.ts
+++ b/app/sebastian/data.ts
@@ -25,6 +25,13 @@ export function wixThumb(uri: string, w: number, h: number): string {
   return `https://static.wixstatic.com/media/${uri}/v1/fill/w_${w},h_${h},al_c,q_85/image.jpg`;
 }
 
+// Logos are transparent PNGs; request PNG output so transparency is preserved.
+// The JPEG output used by wixImage() flattens transparency onto black, which
+// turns black-on-transparent marks (Gucci, CBS, NBC) into solid dark boxes.
+export function wixLogo(uri: string, width = 400): string {
+  return `https://static.wixstatic.com/media/${uri}/v1/fit/w_${width},h_${width},q_90/image.png`;
+}
+
 export const sections: Section[] = [
   {
     slug: "artists",

--- a/app/sebastian/data.ts
+++ b/app/sebastian/data.ts
@@ -185,10 +185,9 @@ export const site = {
 };
 
 export const contact = {
-  email: "Sebastian@Sebastianpiras.com",
-  phone: "+1 646 361 9579",
+  email: "Sebastian@SebastianPiras.com",
   intro:
-    "Sebastian Piras' limited edition prints can be purchased through this website. For editorial and commercial assignments or general inquiries please contact via email or phone.",
+    "For editorial and commercial assignments or general inquiries please contact ",
   redux: {
     prefix: "Additional editorial images also available at ",
     linkText: "reduxpictures.com",

--- a/app/sebastian/layout.tsx
+++ b/app/sebastian/layout.tsx
@@ -1,7 +1,8 @@
 import type { Metadata } from "next";
 import { Cormorant_Garamond, Inter } from "next/font/google";
 import Link from "next/link";
-import { site, sections } from "./data";
+import { site } from "./data";
+import SebNav from "./SebNav";
 
 const cormorant = Cormorant_Garamond({
   subsets: ["latin"],
@@ -24,13 +25,6 @@ export const metadata: Metadata = {
   robots: { index: false, follow: false },
 };
 
-const nav = [
-  ...sections.map((s) => ({ href: `/sebastian/${s.slug}`, label: s.title })),
-  { href: "/sebastian/about", label: "About" },
-  { href: "/sebastian/clients", label: "Clients" },
-  { href: "/sebastian/contact", label: "Contact" },
-];
-
 export default function SebastianLayout({
   children,
 }: Readonly<{ children: React.ReactNode }>) {
@@ -39,7 +33,8 @@ export default function SebastianLayout({
       className={`${cormorant.variable} ${inter.variable} min-h-screen bg-white text-neutral-900`}
       style={{ fontFamily: "var(--font-inter), sans-serif" }}
     >
-      <header className="mx-auto max-w-6xl px-6 pt-12 pb-8">
+      <SebNav />
+      <header className="mx-auto max-w-6xl px-6 pt-28 pb-8">
         <Link href="/sebastian" className="block">
           <h1
             className="text-4xl tracking-wide sm:text-5xl"
@@ -48,33 +43,11 @@ export default function SebastianLayout({
             {site.name}
           </h1>
         </Link>
-        <nav className="mt-6 flex flex-wrap gap-x-5 gap-y-2 text-[11px] uppercase tracking-[0.2em] text-neutral-500">
-          {nav.map((item) => (
-            <Link
-              key={item.href}
-              href={item.href}
-              className="transition-colors hover:text-neutral-900"
-            >
-              {item.label}
-            </Link>
-          ))}
-        </nav>
       </header>
       <main className="mx-auto max-w-6xl px-6 pb-20">{children}</main>
       <footer className="border-t border-neutral-200">
-        <div className="mx-auto flex max-w-6xl flex-wrap items-center justify-between gap-4 px-6 py-8 text-[11px] uppercase tracking-[0.2em] text-neutral-400">
+        <div className="mx-auto flex max-w-6xl items-center px-6 py-8 text-[11px] uppercase tracking-[0.2em] text-neutral-400">
           <span>{site.copyright}</span>
-          <span className="flex gap-5">
-            <Link href="/sebastian/clients" className="hover:text-neutral-900">
-              Clients
-            </Link>
-            <Link href="/sebastian/contact" className="hover:text-neutral-900">
-              Mail
-            </Link>
-            <Link href="/sebastian" className="hover:text-neutral-900">
-              Home
-            </Link>
-          </span>
         </div>
       </footer>
     </div>


### PR DESCRIPTION
Replaces the Sebastian prototype's inline text nav — which duplicated the footer and had no mobile treatment — with a persistent glass segmented bar and hamburger menu so navigation is consistent and reachable on every screen. Also shortens the contact page and carries the earlier client-logo transparency fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)