### PR TITLE
System: move minimap to a left rail with reverb hover

### DIFF
--- a/app/blog/Minimap.tsx
+++ b/app/blog/Minimap.tsx
@@ -10,13 +10,43 @@ interface Section {
 
 interface MinimapProps {
   selector?: string;
+  // Opt-in left-rail variant for /system; the blog keeps its full-TOC popover.
+  reverb?: boolean;
 }
 
-export default function Minimap({ selector = '.blog-prose h2[id], .blog-prose h3[id]' }: MinimapProps) {
+// On hover, notch width tracks proximity to the cursor rather than heading
+// level: the hovered notch peaks and the bonus halves each step out, down to
+// the REVERB_BASE floor. At rest, notches keep their hierarchy widths.
+const REVERB_BASE = 4;
+const REVERB_AMPLITUDE = 30;
+const REVERB_FALLOFF = 0.5;
+
+export default function Minimap({
+  selector = '.blog-prose h2[id], .blog-prose h3[id]',
+  reverb = false,
+}: MinimapProps) {
   const [sections, setSections] = useState<Section[]>([]);
   const [hovering, setHovering] = useState(false);
+  const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
   const [activeId, setActiveId] = useState<string | null>(null);
   const leaveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // One persistent label, not one card per notch, so it keeps its last text
+  // and position while fading out — leaving the rail shouldn't snap it away.
+  const [labelY, setLabelY] = useState(0);
+  const [labelText, setLabelText] = useState('');
+  const [labelWidth, setLabelWidth] = useState(0);
+  const labelTextRef = useRef<HTMLSpanElement>(null);
+
+  useEffect(() => {
+    if (hoveredIndex !== null && sections[hoveredIndex]) {
+      setLabelText(sections[hoveredIndex].text);
+    }
+  }, [hoveredIndex, sections]);
+
+  useEffect(() => {
+    if (labelTextRef.current) setLabelWidth(labelTextRef.current.scrollWidth);
+  }, [labelText]);
 
   const handleEnter = useCallback(() => {
     if (leaveTimer.current) clearTimeout(leaveTimer.current);
@@ -57,6 +87,59 @@ export default function Minimap({ selector = '.blog-prose h2[id], .blog-prose h3
   }, [sections]);
 
   if (sections.length === 0) return null;
+
+  if (reverb) {
+    return (
+      <div className="minimap minimap--reverb" onMouseLeave={() => setHoveredIndex(null)}>
+        <div className="minimap-notches">
+          {sections.map((s, i) => {
+            const restWidth = s.level === 3 ? 10 : 16;
+            const width =
+              hoveredIndex === null
+                ? restWidth
+                : REVERB_BASE + REVERB_AMPLITUDE * Math.pow(REVERB_FALLOFF, Math.abs(i - hoveredIndex));
+            return (
+              <a
+                key={s.id}
+                href={`#${s.id}`}
+                className={`minimap-notch-row ${activeId === s.id ? 'minimap-notch-row--active' : ''} ${hoveredIndex === i ? 'minimap-notch-row--hovered' : ''}`}
+                onMouseEnter={(e) => {
+                  setHoveredIndex(i);
+                  setLabelY(e.currentTarget.offsetTop + e.currentTarget.offsetHeight / 2);
+                }}
+                onFocus={(e) => {
+                  setHoveredIndex(i);
+                  setLabelY(e.currentTarget.offsetTop + e.currentTarget.offsetHeight / 2);
+                }}
+                onBlur={() => setHoveredIndex(null)}
+                onClick={(e) => {
+                  e.preventDefault();
+                  document.getElementById(s.id)?.scrollIntoView({ behavior: 'smooth' });
+                }}
+              >
+                <span
+                  className={`minimap-notch ${s.level === 3 ? 'minimap-notch--sub' : ''} ${activeId === s.id ? 'minimap-notch--active' : ''}`}
+                  style={{ width: `${width}px` }}
+                />
+              </a>
+            );
+          })}
+          <div
+            className={`minimap-label ${hoveredIndex !== null ? 'minimap-label--visible' : ''}`}
+            style={{
+              transform: `translateY(${labelY}px) translateY(-50%)`,
+              width: labelWidth ? `${labelWidth}px` : undefined,
+            }}
+            aria-hidden="true"
+          >
+            <span key={labelText} ref={labelTextRef} className="minimap-label-text">
+              {labelText}
+            </span>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div

--- a/app/system/page.tsx
+++ b/app/system/page.tsx
@@ -66,7 +66,7 @@ export default function SystemPage() {
 
   return (
     <article className="system-page">
-      <Minimap selector=".system-prose h2[id], .system-prose h3[id]" />
+      <Minimap selector=".system-prose h2[id], .system-prose h3[id]" reverb />
       <header className="system-header">
         <div className="system-header-eyebrow">{data.eyebrow ?? 'Design System'}</div>
         <h1>{data.title ?? 'Design System'}</h1>

--- a/app/system/system.css
+++ b/app/system/system.css
@@ -669,8 +669,9 @@
 /* ─── Minimap (shared visual language with /blog) ────────── */
 .minimap {
   position: fixed;
-  top: 24px;
-  right: 24px;
+  top: 50%;
+  left: 24px;
+  transform: translateY(-50%);
   z-index: 100;
   display: flex;
   align-items: flex-start;
@@ -679,7 +680,7 @@
 .minimap-notches {
   display: flex;
   flex-direction: column;
-  align-items: flex-end;
+  align-items: flex-start;
   gap: 6px;
   padding: 8px 6px;
   cursor: pointer;
@@ -706,8 +707,8 @@
 .minimap-popover {
   position: absolute;
   top: 0;
-  right: 100%;
-  margin-right: 8px;
+  left: 100%;
+  margin-left: 8px;
   background: #fff;
   border: 1px solid #e5e5e5;
   border-radius: 8px;
@@ -721,8 +722,8 @@
    so the static override wins on source order. */
 .minimap-popover--demo {
   position: static;
-  right: auto;
-  margin-right: 0;
+  left: auto;
+  margin-left: 0;
 }
 /* The demo lives inside .system-prose, whose `a` rule (underline, hover
    opacity) out-specifies .minimap-link. Restore the real link styling. */
@@ -752,6 +753,88 @@
   color: #1a1a1a;
   font-weight: 600;
 }
+
+/* Reverb variant. Notch widths are set inline (see Minimap.tsx); the rules
+   here cover layout, color, and the label card. */
+.minimap--reverb .minimap-notches {
+  position: relative;
+  gap: 2px;
+  padding: 0;
+  align-items: flex-start;
+}
+.minimap-notch-row {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  width: 34px; /* constant, so the label anchors at a fixed x as bars grow */
+  padding: 3px 0;
+  cursor: pointer;
+  text-decoration: none;
+}
+.minimap--reverb .minimap-notch {
+  display: block;
+}
+/* While hovering the rail, only the hovered notch goes dark — the scroll-active
+   notch drops to grey so there's a single point of emphasis. */
+.minimap--reverb:hover .minimap-notch {
+  background: #ccc;
+}
+.minimap--reverb .minimap-notch-row--hovered .minimap-notch {
+  background: #1a1a1a;
+}
+/* Transitions make moving down the rail read as one label morphing rather
+   than a new card popping in per notch. */
+.minimap-label {
+  position: absolute;
+  left: 100%;
+  top: 0;
+  margin-left: 12px;
+  box-sizing: content-box;
+  background: #fff;
+  border: 1px solid #e5e5e5;
+  border-radius: 8px;
+  padding: 6px 12px;
+  font-size: 13px;
+  color: #1a1a1a;
+  white-space: nowrap;
+  overflow: hidden;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
+  pointer-events: none;
+  opacity: 0;
+  transition:
+    transform 0.28s cubic-bezier(0.22, 1, 0.36, 1),
+    width 0.28s cubic-bezier(0.22, 1, 0.36, 1),
+    opacity 0.2s ease;
+}
+.minimap-label--visible {
+  opacity: 1;
+}
+.minimap-label-text {
+  display: inline-block;
+  white-space: nowrap;
+  animation: minimap-label-in 0.3s ease;
+}
+@keyframes minimap-label-in {
+  from {
+    opacity: 0;
+    filter: blur(4px);
+    transform: translateY(3px);
+  }
+  to {
+    opacity: 1;
+    filter: blur(0);
+    transform: none;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .minimap-label,
+  .minimap-label-text {
+    transition: opacity 0.2s ease;
+    animation: none;
+  }
+}
+
 @media (max-width: 768px) {
   .minimap {
     display: none;


### PR DESCRIPTION
Reworks the /system minimap into a vertically-centered left rail with a proximity-based hover ripple and a single sliding label, so navigating sections feels more tactile and legible. Gated behind an opt-in `reverb` prop, leaving the blog's minimap unchanged.