### PR TITLE
System: reorder sections and promote logo to top level

### DIFF
--- a/app/system/components/ChromeDemos.tsx
+++ b/app/system/components/ChromeDemos.tsx
@@ -40,7 +40,7 @@ export function LogoDemo() {
   return (
     <>
       <div className="logo-demo-header">
-        <h3 id="logo">Logo</h3>
+        <h2 id="logo">Logo</h2>
         <div className="segmented" role="tablist" aria-label="Logo variant">
           {LOGO_VARIANTS.map((v) => (
             <button

--- a/app/system/system.css
+++ b/app/system/system.css
@@ -319,7 +319,7 @@
   gap: 16px;
   margin: 40px 0 12px;
 }
-.logo-demo-header h3 {
+.logo-demo-header h2 {
   margin: 0;
 }
 .logo-demo {

--- a/content/system.mdx
+++ b/content/system.mdx
@@ -3,6 +3,8 @@ title: Design System
 eyebrow: MVXMXM
 ---
 
+<LogoDemo />
+
 ## Color
 
 <Swatches>
@@ -27,27 +29,6 @@ Two faces do the work: **Archivo** for everything structural, and **Homemade App
 <Type name="Body" sample="The quick brown fox jumps over the lazy dog." size="16px" weight={400} font="sans" note="line-height 1.75" />
 <Type name="Handwritten accent" sample="words by maximillian" size="20px" weight={400} font="handwritten" note="dates, eyebrows, labels" />
 <Type name="Mono" sample="const tokens = true" size="14px" weight={400} font="mono" note="code only" />
-
-## Radius
-
-Soft, generous corners. Pills (`40px`) for floating chrome, large radii for cards.
-
-<Swatches>
-  <RadiusBox name="Chip / input" value="6px" />
-  <RadiusBox name="Code / small" value="8px" />
-  <RadiusBox name="Card" value="16px" />
-  <RadiusBox name="Card (folio)" value="24px" />
-  <RadiusBox name="Hero card" value="36px" />
-  <RadiusBox name="Pill" value="40px" />
-</Swatches>
-
-## Motion
-
-Almost everything eases between `0.2s` and `0.5s`. `FolioEngine` uses `0.35s ease` as its house transition; text effects use `cubic-bezier(0.4, 0, 0.2, 1)`. Motion is built on **framer-motion** via the `registry/` primitives below — prefer those over hand-rolled keyframes.
-
-- **Standard transition:** `all 0.35s ease`
-- **Quick (hover/opacity):** `0.2s ease`
-- **Easing curve:** `cubic-bezier(0.4, 0, 0.2, 1)`
 
 ## Components
 
@@ -75,8 +56,6 @@ Almost everything eases between `0.2s` and `0.5s`. `FolioEngine` uses `0.35s eas
   <ChatDemo />
 </ComponentPreview>
 
-<LogoDemo />
-
 ### Nav bar
 
 <NavDemo />
@@ -86,3 +65,24 @@ Almost everything eases between `0.2s` and `0.5s`. `FolioEngine` uses `0.35s eas
 <ComponentPreview>
   <MenuDemo />
 </ComponentPreview>
+
+## Radius
+
+Soft, generous corners. Pills (`40px`) for floating chrome, large radii for cards.
+
+<Swatches>
+  <RadiusBox name="Chip / input" value="6px" />
+  <RadiusBox name="Code / small" value="8px" />
+  <RadiusBox name="Card" value="16px" />
+  <RadiusBox name="Card (folio)" value="24px" />
+  <RadiusBox name="Hero card" value="36px" />
+  <RadiusBox name="Pill" value="40px" />
+</Swatches>
+
+## Motion
+
+Almost everything eases between `0.2s` and `0.5s`. `FolioEngine` uses `0.35s ease` as its house transition; text effects use `cubic-bezier(0.4, 0, 0.2, 1)`. Motion is built on **framer-motion** via the `registry/` primitives below — prefer those over hand-rolled keyframes.
+
+- **Standard transition:** `all 0.35s ease`
+- **Quick (hover/opacity):** `0.2s ease`
+- **Easing curve:** `cubic-bezier(0.4, 0, 0.2, 1)`


### PR DESCRIPTION
Reorders the `/system` reference so it reads in the order the design system is consumed: logo first (promoted out of Components to a top-level `h2` section), then color, typography, components, and finally the radius & motion tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)