### PR TITLE
System: rebuild color palette on a slate ramp with interactive swatches

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,9 +1,28 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
-  --background-alt: #f5f5f5;
-  --foreground: #1a1a1a;
+  /* Blue-leaning `slate` so the neutrals echo the accent's cool undertone.
+     Keep in sync with SLATE_SCALE in app/system/components/ColorScale.tsx. */
+  --slate-50: #f8fafc;
+  --slate-100: #f1f5f9;
+  --slate-200: #e2e8f0;
+  --slate-300: #cad5e2;
+  --slate-400: #90a1b9;
+  --slate-500: #62748e;
+  --slate-600: #45556c;
+  --slate-700: #314158;
+  --slate-800: #1d293d;
+  --slate-900: #0f172b;
+  --slate-950: #020618;
+
+  --background: var(--slate-50);
+  --surface: #fcfcfc;
+  --background-alt: var(--slate-100);
+  --hairline: var(--slate-200);
+  --border: var(--slate-300);
+  --subtle: var(--slate-400);
+  --muted: var(--slate-500);
+  --foreground: var(--slate-900);
   --accent: #00BBFF;
   --font-sans: var(--font-archivo), 'Archivo', sans-serif;
   --font-handwritten: var(--font-homemade-apple), 'Homemade Apple', cursive;
@@ -11,7 +30,12 @@
 
 @theme inline {
   --color-background: var(--background);
+  --color-surface: var(--surface);
   --color-background-alt: var(--background-alt);
+  --color-hairline: var(--hairline);
+  --color-border: var(--border);
+  --color-subtle: var(--subtle);
+  --color-muted: var(--muted);
   --color-foreground: var(--foreground);
   --color-accent: var(--accent);
 }
@@ -99,8 +123,8 @@ body {
 .experiment-card {
   flex: 1 1 100%;
   min-width: 100%;
-  background: #ffffff;
-  border: 1px solid #e5e7eb;
+  background: var(--surface);
+  border: 1px solid var(--hairline);
   border-radius: 16px;
   padding: 0;
   text-decoration: none;
@@ -136,13 +160,13 @@ body {
 .experiment-card:hover {
   transform: translateY(-4px);
   box-shadow: 0 12px 24px rgba(0, 0, 0, 0.08);
-  border-color: #d1d5db;
+  border-color: var(--border);
 }
 
 .experiment-preview {
   width: 400%;
   height: 400%;
-  background: #f9fafb;
+  background: var(--background);
   border: none;
   display: block;
   pointer-events: none;
@@ -164,7 +188,7 @@ body {
   top: 0;
   left: 0;
   overflow: hidden;
-  background: #f9fafb;
+  background: var(--background);
 }
 
 @media (max-width: 768px) {

--- a/app/system/components/ColorScale.tsx
+++ b/app/system/components/ColorScale.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import React, { useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+
+type Shade = { step: string; value: string };
+
+// Keep in sync with app/globals.css (--slate-*); step 0 is the off-ramp surface.
+const SLATE_SCALE: Shade[] = [
+  { step: '0', value: '#fcfcfc' },
+  { step: '50', value: '#f8fafc' },
+  { step: '100', value: '#f1f5f9' },
+  { step: '200', value: '#e2e8f0' },
+  { step: '300', value: '#cad5e2' },
+  { step: '400', value: '#90a1b9' },
+  { step: '500', value: '#62748e' },
+  { step: '600', value: '#45556c' },
+  { step: '700', value: '#314158' },
+  { step: '800', value: '#1d293d' },
+  { step: '900', value: '#0f172b' },
+  { step: '950', value: '#020618' },
+];
+
+function CheckIcon() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path d="M20 6L9 17l-5-5" stroke="currentColor" strokeWidth="2.6" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+function ColorSwatch({ step, value }: Shade) {
+  const [copied, setCopied] = useState(false);
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(value);
+    } catch {
+      // clipboard blocked — nothing else to fall back to for a raw value
+    }
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1400);
+  };
+
+  return (
+    <button
+      type="button"
+      className="scale-swatch"
+      onClick={copy}
+      aria-label={`Copy ${value}`}
+      data-copied={copied || undefined}
+    >
+      <span className="scale-chip" style={{ background: value }} aria-hidden />
+      <span className="scale-tip" role="tooltip">
+        <AnimatePresence mode="popLayout" initial={false}>
+          <motion.span
+            key={copied ? 'check' : 'label'}
+            initial={{ opacity: 0, y: 3, filter: 'blur(4px)' }}
+            animate={{ opacity: 1, y: 0, filter: 'blur(0px)' }}
+            exit={{ opacity: 0, y: 3, filter: 'blur(4px)' }}
+            transition={{ duration: 0.3, ease: 'easeOut' }}
+            className="scale-tip-inner"
+          >
+            {copied ? (
+              <>
+                <CheckIcon /> copied
+              </>
+            ) : (
+              <>
+                {step} · {value}
+              </>
+            )}
+          </motion.span>
+        </AnimatePresence>
+      </span>
+    </button>
+  );
+}
+
+export function ColorScale({ steps }: { steps?: Shade[] }) {
+  return (
+    <div className="scale">
+      <div className="scale-row">
+        {(steps ?? []).map((s) => (
+          <ColorSwatch key={s.step + s.value} step={s.step} value={s.value} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+const ACCENT: Shade = { step: 'accent', value: '#00BBFF' };
+
+// A no-prop tag because MDX drops array-valued attributes, so the data can't
+// be passed to <ColorScale> from system.mdx.
+export function Palette() {
+  return <ColorScale steps={[...SLATE_SCALE, ACCENT]} />;
+}

--- a/app/system/page.tsx
+++ b/app/system/page.tsx
@@ -11,6 +11,7 @@ import {
   RadiusBox,
   Type,
 } from './components/TokenSwatch';
+import { Palette } from './components/ColorScale';
 import { ComponentPreview } from './components/ComponentPreview';
 import { AnchorHeading } from './components/AnchorHeading';
 import { LogoDemo, NavDemo, MenuDemo } from './components/ChromeDemos';
@@ -47,6 +48,7 @@ const mdxComponents: MDXComponents = {
   // Doc helpers
   Swatches,
   Swatch,
+  Palette,
   RadiusBox,
   Type,
   ComponentPreview,

--- a/app/system/system.css
+++ b/app/system/system.css
@@ -2,8 +2,8 @@
 
 .system-layout {
   min-height: 100vh;
-  background: #fff;
-  color: #1a1a1a;
+  background: var(--background);
+  color: var(--foreground);
   font-family: var(--font-archivo), 'Archivo', sans-serif;
 }
 
@@ -227,6 +227,98 @@
   line-height: 1.4;
 }
 
+/* ─── Color scale (Tailwind-docs style ramp) ─────────────── */
+.scale {
+  margin: 8px 0 28px;
+}
+/* 7 columns so the 13 swatches land in two even-ish rows. */
+.scale-row {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 10px;
+}
+.scale-swatch {
+  position: relative;
+  display: block;
+  width: 100%;
+  min-width: 0;
+  padding: 0;
+  border: none;
+  background: none;
+  font: inherit;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+}
+.scale-chip {
+  display: block;
+  width: 100%;
+  height: 88px;
+  border-radius: 10px;
+  border: 1px solid rgba(15, 23, 43, 0.08);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+.scale-swatch:hover .scale-chip {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 14px rgba(15, 23, 43, 0.12);
+}
+.scale-swatch:active .scale-chip {
+  transform: translateY(0) scale(0.97);
+}
+.scale-swatch:focus-visible {
+  outline: none;
+}
+.scale-swatch:focus-visible .scale-chip {
+  box-shadow: 0 0 0 2px var(--background), 0 0 0 4px var(--accent);
+}
+
+/* Keep in sync with the minimap reverb label so the two read as one system. */
+.scale-tip {
+  position: absolute;
+  bottom: calc(100% + 10px);
+  left: 50%;
+  z-index: 5;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 12px;
+  border-radius: 8px;
+  background: var(--surface);
+  border: 1px solid #e5e5e5;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
+  color: #1a1a1a;
+  font-family: var(--font-archivo), 'Archivo', sans-serif;
+  font-size: 13px;
+  line-height: normal;
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;
+  transform: translateX(-50%) translateY(4px);
+  transition:
+    opacity 0.2s ease,
+    transform 0.28s cubic-bezier(0.22, 1, 0.36, 1);
+}
+.scale-swatch:hover .scale-tip,
+.scale-swatch:focus-visible .scale-tip,
+.scale-swatch[data-copied] .scale-tip {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+}
+.scale-tip-inner {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+.scale-tip-inner svg {
+  display: block;
+}
+
+@media (max-width: 640px) {
+  .scale-row {
+    grid-template-columns: repeat(4, 1fr);
+    gap: 8px;
+  }
+}
+
 /* ─── Type specimens ─────────────────────────────────────── */
 .type-specimen {
   padding: 20px 0;
@@ -263,7 +355,7 @@
   padding: 40px 24px;
 }
 .component-preview-canvas--light {
-  background: #fff;
+  background: var(--surface);
 }
 .component-preview-canvas--dark {
   background: #1a1a1a;
@@ -307,7 +399,7 @@
   margin: 24px 0 40px;
   border: 1px solid #e5e7eb;
   border-radius: 16px;
-  background: #fff;
+  background: var(--surface);
 }
 
 /* Logo demo: live Lottie mark with a segmented control to swap faces.
@@ -360,7 +452,7 @@
   color: #1a1a1a;
 }
 .segmented-option--active {
-  background: #fff;
+  background: var(--surface);
   color: #1a1a1a;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12);
 }
@@ -410,7 +502,7 @@
 }
 /* Secondary — hairline outline on white. */
 .ui-button--secondary {
-  background: #fff;
+  background: var(--surface);
   border-color: #e5e7eb;
   color: #1a1a1a;
 }
@@ -453,7 +545,7 @@
   font-family: var(--font-archivo), 'Archivo', sans-serif;
   font-size: 16px;
   color: #1a1a1a;
-  background: #fff;
+  background: var(--surface);
   border: 2px solid rgba(0, 0, 0, 0.15);
   border-radius: 16px;
   outline: none;
@@ -512,7 +604,7 @@
   max-width: 340px;
   aspect-ratio: 3 / 2;
   padding: 24px;
-  background: #fff;
+  background: var(--surface);
   border-radius: 16px;
   box-shadow:
     0 20px 40px rgba(0, 0, 0, 0.08),
@@ -709,7 +801,7 @@
   top: 0;
   left: 100%;
   margin-left: 8px;
-  background: #fff;
+  background: var(--surface);
   border: 1px solid #e5e5e5;
   border-radius: 8px;
   padding: 8px 0;
@@ -791,7 +883,7 @@
   top: 0;
   margin-left: 12px;
   box-sizing: content-box;
-  background: #fff;
+  background: var(--surface);
   border: 1px solid #e5e5e5;
   border-radius: 8px;
   padding: 6px 12px;

--- a/content/system.mdx
+++ b/content/system.mdx
@@ -7,17 +7,7 @@ eyebrow: MVXMXM
 
 ## Color
 
-<Swatches>
-  <Swatch name="Background" value="#ffffff" color="#ffffff" />
-  <Swatch name="Foreground / Ink" value="#1a1a1a" color="#1a1a1a" />
-  <Swatch name="Accent" value="#00BBFF" color="#00BBFF" />
-  <Swatch name="Muted text" value="#666666" color="#666666" />
-  <Swatch name="Subtle text" value="#999999" color="#999999" />
-  <Swatch name="Hairline" value="#e0e0e0" color="#e0e0e0" />
-  <Swatch name="Border" value="#e5e7eb" color="#e5e7eb" />
-  <Swatch name="Background alt" value="#f5f5f5" color="#f5f5f5" />
-  <Swatch name="Surface alt" value="#f9fafb" color="#f9fafb" />
-</Swatches>
+<Palette />
 
 ## Typography
 


### PR DESCRIPTION
Makes the design-system neutrals feel intentional against the `#00BBFF` accent by rebuilding the palette on Tailwind's blue-leaning `slate` ramp, surfaced on `/system` as an interactive copy-to-clipboard ramp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)