### PR TITLE
System: give the minimap label a direction-aware text reel

### DIFF
--- a/app/blog/Minimap.tsx
+++ b/app/blog/Minimap.tsx
@@ -38,11 +38,33 @@ export default function Minimap({
   const [labelWidth, setLabelWidth] = useState(0);
   const labelTextRef = useRef<HTMLSpanElement>(null);
 
+  // Roll direction tracks cursor travel through the rail, so successive labels
+  // read as one reel advancing rather than a cross-fade in place.
+  const [prevLabel, setPrevLabel] = useState<string | null>(null);
+  const [dir, setDir] = useState<1 | -1>(1);
+  const curTextRef = useRef('');
+  const prevIndexRef = useRef<number | null>(null);
+  const swapTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   useEffect(() => {
-    if (hoveredIndex !== null && sections[hoveredIndex]) {
-      setLabelText(sections[hoveredIndex].text);
+    if (hoveredIndex === null || !sections[hoveredIndex]) return;
+    const nextText = sections[hoveredIndex].text;
+    const cur = curTextRef.current;
+    if (cur && cur !== nextText) {
+      const pi = prevIndexRef.current;
+      setDir(pi !== null && hoveredIndex < pi ? -1 : 1);
+      setPrevLabel(cur);
+      if (swapTimer.current) clearTimeout(swapTimer.current);
+      swapTimer.current = setTimeout(() => setPrevLabel(null), 320);
     }
+    curTextRef.current = nextText;
+    prevIndexRef.current = hoveredIndex;
+    setLabelText(nextText);
   }, [hoveredIndex, sections]);
+
+  useEffect(() => () => {
+    if (swapTimer.current) clearTimeout(swapTimer.current);
+  }, []);
 
   useEffect(() => {
     if (labelTextRef.current) setLabelWidth(labelTextRef.current.scrollWidth);
@@ -132,8 +154,22 @@ export default function Minimap({
             }}
             aria-hidden="true"
           >
-            <span key={labelText} ref={labelTextRef} className="minimap-label-text">
-              {labelText}
+            <span className="minimap-label-reel">
+              {prevLabel !== null && (
+                <span
+                  key={`out-${prevLabel}`}
+                  className={`minimap-label-text minimap-label-text--out ${dir === 1 ? 'is-down' : 'is-up'}`}
+                >
+                  {prevLabel}
+                </span>
+              )}
+              <span
+                key={`in-${labelText}`}
+                ref={labelTextRef}
+                className={`minimap-label-text minimap-label-text--in ${dir === 1 ? 'is-down' : 'is-up'}`}
+              >
+                {labelText}
+              </span>
             </span>
           </div>
         </div>

--- a/app/system/system.css
+++ b/app/system/system.css
@@ -878,6 +878,7 @@
 /* Transitions make moving down the rail read as one label morphing rather
    than a new card popping in per notch. */
 .minimap-label {
+  --minimap-label-blur: 2px;
   position: absolute;
   left: 100%;
   top: 0;
@@ -902,28 +903,59 @@
 .minimap-label--visible {
   opacity: 1;
 }
+/* Outgoing copy overlays absolutely so it can roll away without widening the
+   content-fit box. */
+.minimap-label-reel {
+  position: relative;
+  display: inline-block;
+}
 .minimap-label-text {
   display: inline-block;
   white-space: nowrap;
-  animation: minimap-label-in 0.3s ease;
 }
-@keyframes minimap-label-in {
-  from {
-    opacity: 0;
-    filter: blur(4px);
-    transform: translateY(3px);
-  }
-  to {
-    opacity: 1;
-    filter: blur(0);
-    transform: none;
-  }
+.minimap-label-text--out {
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+.minimap-label-text--in.is-down {
+  animation: minimap-label-in-down 0.3s cubic-bezier(0.22, 1, 0.36, 1);
+}
+.minimap-label-text--in.is-up {
+  animation: minimap-label-in-up 0.3s cubic-bezier(0.22, 1, 0.36, 1);
+}
+.minimap-label-text--out.is-down {
+  animation: minimap-label-out-down 0.3s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+.minimap-label-text--out.is-up {
+  animation: minimap-label-out-up 0.3s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+@keyframes minimap-label-in-down {
+  from { opacity: 0; filter: blur(var(--minimap-label-blur)); transform: translateY(70%); }
+  to { opacity: 1; filter: blur(0); transform: none; }
+}
+@keyframes minimap-label-in-up {
+  from { opacity: 0; filter: blur(var(--minimap-label-blur)); transform: translateY(-70%); }
+  to { opacity: 1; filter: blur(0); transform: none; }
+}
+@keyframes minimap-label-out-down {
+  from { opacity: 1; filter: blur(0); transform: none; }
+  to { opacity: 0; filter: blur(var(--minimap-label-blur)); transform: translateY(-70%); }
+}
+@keyframes minimap-label-out-up {
+  from { opacity: 1; filter: blur(0); transform: none; }
+  to { opacity: 0; filter: blur(var(--minimap-label-blur)); transform: translateY(70%); }
 }
 @media (prefers-reduced-motion: reduce) {
-  .minimap-label,
-  .minimap-label-text {
+  .minimap-label {
     transition: opacity 0.2s ease;
+  }
+  .minimap-label-text--in,
+  .minimap-label-text--out {
     animation: none;
+  }
+  .minimap-label-text--out {
+    display: none;
   }
 }
 


### PR DESCRIPTION
Makes the /system minimap label swap text as a direction-aware reel — old text rolls out and new text rolls in the way the cursor is travelling — so moving through the rail reads as one continuous motion rather than a cross-fade in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)