### PR TITLE
Reader: add WSJ AI-future opinion to reading list

### DIFF
--- a/public/reader/reading-list.json
+++ b/public/reader/reading-list.json
@@ -791,6 +791,14 @@
       "createdAt": "2026-07-23T12:01:00.000Z",
       "metadata": {},
       "read": false
+    },
+    {
+      "id": "1781352000016",
+      "url": "https://www.wsj.com/opinion/the-ai-future-is-for-everyone-a0c24e20",
+      "title": "The AI Future Is for Everyone",
+      "createdAt": "2026-07-30T12:00:00.000Z",
+      "metadata": {},
+      "read": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds the WSJ opinion piece “The AI Future Is for Everyone” to the reading list.

## Test plan
- [ ] Confirm the new entry appears in `/reader` (or the spiral reading-list view)
- [ ] Click through to the WSJ URL and verify it opens


Made with [Cursor](https://cursor.com)